### PR TITLE
AMPLIFY-85: Refactor code logic for constructor

### DIFF
--- a/template-service/backend_template/repositories/base.py
+++ b/template-service/backend_template/repositories/base.py
@@ -18,7 +18,7 @@ class BaseRepository(Generic[ModelType]):
     Dependencies are injected automatically by FastAPI.
     """
     
-    def __init__(self, model: Type[ModelType], db: Annotated[AsyncSession, Depends(get_db)]):
+    def __init__(self, model: Type[ModelType], db: AsyncSession):
         """
         :param model: The SQLAlchemy model class (e.g. ProjectTemplate)
         :param db: The AsyncSession injected by FastAPI


### PR DESCRIPTION
Closes #85
Removed unnecessary dependency injection from init constructor of the BaseRepository class