### PR TITLE
AMPLIFY-190 : Add gemini image nodes

### DIFF
--- a/template-service/backend_template/engine/comfy_api_nodes/apis/gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/apis/gemini.py
@@ -63,6 +63,15 @@ class GeminiFileData(BaseModel):
     mimeType: GeminiMimeType | None = Field(None)
 
 
+# class UploadFileDto(BaseModel):
+#     mediaId: str
+#     mediaPath: str
+#     contentType: str
+
+class GetLinkByIdResponse(BaseModel):
+    mediaId: str | None = None
+    link: str | None = None
+
 class GeminiPart(BaseModel):
     inlineData: GeminiInlineData | None = Field(None)
     fileData: GeminiFileData | None = Field(None)
@@ -139,8 +148,7 @@ class GeminiImageGenerateContentRequest(BaseModel):
     systemInstruction: GeminiSystemInstructionContent | None = Field(None)
     tools: list[GeminiTool] | None = Field(None)
     videoMetadata: GeminiVideoMetadata | None = Field(None)
-    uploadImagesToStorage: bool = Field(True)
-
+    # uploadImagesToStorage: bool = Field(True)
 
 class GeminiGenerateContentRequest(BaseModel):
     contents: list[GeminiContent] = Field(...)

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
@@ -28,6 +28,7 @@ from comfy_api_nodes.apis.gemini import (
     GeminiSystemInstructionContent,
     GeminiTextPart,
     Modality,
+    GetLinkByIdResponse,
 )
 from comfy_api_nodes.util import (
     ApiEndpoint,
@@ -37,7 +38,10 @@ from comfy_api_nodes.util import (
 
 from config import gemini_config, media_ingest_config
 
-GEMINI_BASE_ENDPOINT = f"https://{gemini_config.location}-aiplatform.googleapis.com/v1/projects/{gemini_config.project_id}/locations/{gemini_config.location}/publishers/google/models"
+import base64
+import uuid
+
+GEMINI_BASE_ENDPOINT = f"https://aiplatform.googleapis.com/v1/projects/{gemini_config.project_id}/locations/{gemini_config.location}/publishers/google/models"
 
 _gcp_credentials = None
 
@@ -74,10 +78,6 @@ class GeminiImageModel(str, Enum):
 
     gemini_2_5_flash_image_preview = "gemini-2.5-flash-image-preview"
     gemini_2_5_flash_image = "gemini-2.5-flash-image"
-
-class GetLinkByIdResponse(BaseModel):
-    mediaId: str | None = None
-    link: str | None = None
 
 async def fetch_media_uri_from_ingest(
     cls: type[IO.ComfyNode],
@@ -200,7 +200,106 @@ def get_text_from_response(response: GeminiGenerateContentResponse) -> str:
     return "\n".join([part.text for part in parts])
 
 
-class GeminiNodeAmplify(IO.ComfyNode):
+async def upload_images_and_get_uuids(cls: type[IO.ComfyNode], response: GeminiGenerateContentResponse) -> str:
+    image_uuids: list[str] = []
+    parts = get_parts_by_type(response, "image/*")
+    
+    upload_url = f"{media_ingest_config.media_ingest_url}/internal/media"
+    
+    for idx, part in enumerate(parts):
+        if part.inlineData:
+            image_data = base64.b64decode(part.inlineData.data)
+            
+            ext = "png"
+            if part.inlineData.mimeType:
+                mime = part.inlineData.mimeType.value
+                if "jpeg" in mime or "jpg" in mime:
+                    ext = "jpg"
+                elif "webp" in mime:
+                    ext = "webp"
+            
+            filename = f"gemini_output_{uuid.uuid4().hex[:8]}.{ext}"
+            
+            import requests
+            import asyncio
+            import logging
+            
+            def safe_sync_upload():
+                resp = requests.post(
+                    upload_url, 
+                    headers={"Accept": "application/json"},
+                    files={"file": (filename, image_data, f"image/{ext}")}
+                )
+                resp.raise_for_status()
+                return resp.json()
+
+            try:
+                # Delegate the blocking IO to a background OS thread to save the event loop
+                json_data = await asyncio.to_thread(safe_sync_upload)
+                image_uuids.append(json_data["mediaId"])
+            except Exception as e:
+                logging.error(f"Failed to upload to Media Ingest API via requests thread: {e}")
+                raise
+
+        else:
+            # If Vertex returned it as a Vertex URI (unlikely but possible),
+            # we would need to download and re-upload. For now, throw an error.
+            raise NotImplementedError("Vertex returned a fileUri instead of inlineData, which is not currently mapped for upload.")
+
+    if len(image_uuids) == 0:
+        return ""
+        
+    if len(image_uuids) > 1:
+        raise ValueError(f"Expected 1 image from Gemini, but received {len(image_uuids)}.")
+
+    return image_uuids[0]
+
+
+def calculate_tokens_price(response: GeminiGenerateContentResponse) -> float | None:
+    if not response.modelVersion:
+        return None
+    # Define prices (Cost per 1,000,000 tokens), see https://cloud.google.com/vertex-ai/generative-ai/pricing
+    if response.modelVersion in ("gemini-2.5-pro-preview-05-06", "gemini-2.5-pro"):
+        input_tokens_price = 1.25
+        output_text_tokens_price = 10.0
+        output_image_tokens_price = 0.0
+    elif response.modelVersion in (
+        "gemini-2.5-flash-preview-04-17",
+        "gemini-2.5-flash",
+    ):
+        input_tokens_price = 0.30
+        output_text_tokens_price = 2.50
+        output_image_tokens_price = 0.0
+    elif response.modelVersion in (
+        "gemini-2.5-flash-image-preview",
+        "gemini-2.5-flash-image",
+    ):
+        input_tokens_price = 0.30
+        output_text_tokens_price = 2.50
+        output_image_tokens_price = 30.0
+    elif response.modelVersion == "gemini-3-pro-preview":
+        input_tokens_price = 2
+        output_text_tokens_price = 12.0
+        output_image_tokens_price = 0.0
+    elif response.modelVersion == "gemini-3-pro-image-preview":
+        input_tokens_price = 2
+        output_text_tokens_price = 12.0
+        output_image_tokens_price = 120.0
+    else:
+        return None
+    final_price = response.usageMetadata.promptTokenCount * input_tokens_price
+    if response.usageMetadata.candidatesTokensDetails:
+        for i in response.usageMetadata.candidatesTokensDetails:
+            if i.modality == Modality.IMAGE:
+                final_price += output_image_tokens_price * i.tokenCount  # for Nano Banana models
+            else:
+                final_price += output_text_tokens_price * i.tokenCount
+    if response.usageMetadata.thoughtsTokenCount:
+        final_price += output_text_tokens_price * response.usageMetadata.thoughtsTokenCount
+    return final_price / 1_000_000.0
+
+
+class GeminiNode(IO.ComfyNode):
     """
     Node to generate text responses from a Gemini model.
 
@@ -219,8 +318,8 @@ class GeminiNodeAmplify(IO.ComfyNode):
             max=10
         )
         return IO.Schema(
-            node_id="GeminiNodeAmplify",
-            display_name="Google Gemini Amplify",
+            node_id="GeminiNode",
+            display_name="Google Gemini",
             category="api node/text/Gemini",
             description="Generate text responses with Google's Gemini AI model. "
             "You can provide multiple types of inputs (text, images, audio, video) "
@@ -323,3 +422,233 @@ class GeminiNodeAmplify(IO.ComfyNode):
 
         output_text = get_text_from_response(response)
         return IO.NodeOutput(output_text or "Empty response from Gemini model...")
+
+class GeminiImageNode(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        autogrow_template = IO.Autogrow.TemplatePrefix(
+            input=IO.String.Input("image_uuid", optional=True, tooltip="A Media Ingest API UUID representing an uploaded image"),
+            prefix="image_uuid",
+            min=1,
+            max=3
+        )
+        return IO.Schema(
+            node_id="GeminiImageNode",
+            display_name="Nano Banana (Google Gemini Image)",
+            category="api node/image/Gemini",
+            description="Edit images synchronously via Google API.",
+            inputs=[
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    tooltip="Text prompt for generation",
+                    default="",
+                ),
+                IO.Combo.Input(
+                    "model",
+                    options=GeminiImageModel,
+                    default=GeminiImageModel.gemini_2_5_flash_image,
+                    tooltip="The Gemini model to use for generating responses.",
+                ),
+                IO.Combo.Input(
+                    "aspect_ratio",
+                    options=["auto", "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    default="auto",
+                    tooltip="Defaults to matching the output image size to that of your input image, "
+                    "or otherwise generates 1:1 squares.",
+                    optional=True,
+                ),
+                IO.Autogrow.Input(
+                    "images",
+                    template=autogrow_template,
+                    optional=True,
+                    tooltip="Optional image UUIDs to use as context for the model.",
+                ),
+                IO.Combo.Input(
+                    "response_modalities",
+                    options=["IMAGE+TEXT", "IMAGE"],
+                    tooltip="Choose 'IMAGE' for image-only output, or "
+                    "'IMAGE+TEXT' to return both the generated image and a text response.",
+                    optional=True,
+                    advanced=True,
+                ),
+                IO.String.Input(
+                    "system_prompt",
+                    multiline=True,
+                    default=GEMINI_IMAGE_SYS_PROMPT,
+                    optional=True,
+                    tooltip="Foundational instructions that dictate an AI's behavior.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="image_uuid"),
+                IO.String.Output(display_name="text"),
+            ],
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        model: str,
+        aspect_ratio: str = "auto",
+        images: IO.Autogrow.Type | None = None,
+        response_modalities: str = "IMAGE+TEXT",
+        system_prompt: str = "",
+    ) -> IO.NodeOutput:
+        prompt = validate_string(prompt, strip_whitespace=True, min_length=1)
+        parts: list[GeminiPart] = [GeminiPart(text=prompt)]
+
+        if not aspect_ratio:
+            aspect_ratio = "auto"  # for backward compatability with old workflows; to-do remove this in December
+        image_config = GeminiImageConfig() if aspect_ratio == "auto" else GeminiImageConfig(aspectRatio=aspect_ratio)
+
+        if images is not None:
+            parts.extend(await create_image_parts(cls, images))
+
+        gemini_system_prompt = None
+        if system_prompt:
+            gemini_system_prompt = GeminiSystemInstructionContent(parts=[GeminiTextPart(text=system_prompt)], role=None)
+
+        token = get_vertex_ai_access_token()
+
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(
+                path=f"{GEMINI_BASE_ENDPOINT}/{model}:generateContent", 
+                method="POST", 
+                headers={"Authorization": f"Bearer {token}"}
+            ),
+            data=GeminiImageGenerateContentRequest(
+                contents=[
+                    GeminiContent(role=GeminiRole.user, parts=parts),
+                ],
+                generationConfig=GeminiImageGenerationConfig(
+                    responseModalities=(["IMAGE"] if response_modalities == "IMAGE" else ["TEXT", "IMAGE"]),
+                    imageConfig=image_config,
+                ),
+                systemInstruction=gemini_system_prompt,
+            ),
+            response_model=GeminiGenerateContentResponse,
+        )
+
+        return IO.NodeOutput(await upload_images_and_get_uuids(cls, response), get_text_from_response(response))
+
+class GeminiImage2Node(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        autogrow_template = IO.Autogrow.TemplatePrefix(
+            input=IO.String.Input("image_uuid", optional=True, tooltip="A Media Ingest API UUID representing an uploaded image"),
+            prefix="image_uuid",
+            min=1,
+            max=14
+        )
+        return IO.Schema(
+            node_id="GeminiImage2Node",
+            display_name="Nano Banana Pro (Google Gemini Image)",
+            category="api node/image/Gemini",
+            description="Generate or edit images synchronously via Google Vertex API.",
+            inputs=[
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    tooltip="Text prompt describing the image to generate or the edits to apply. "
+                    "Include any constraints, styles, or details the model should follow.",
+                    default="",
+                ),
+                IO.Combo.Input(
+                    "model",
+                    options=["gemini-3-pro-image-preview"],
+                ),
+                IO.Combo.Input(
+                    "aspect_ratio",
+                    options=["auto", "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    default="auto",
+                    tooltip="If set to 'auto', matches your input image's aspect ratio; "
+                    "if no image is provided, a 16:9 square is usually generated.",
+                ),
+                IO.Combo.Input(
+                    "resolution",
+                    options=["1K", "2K", "4K"],
+                    tooltip="Target output resolution. For 2K/4K the native Gemini upscaler is used.",
+                ),
+                IO.Combo.Input(
+                    "response_modalities",
+                    options=["IMAGE+TEXT", "IMAGE"],
+                    tooltip="Choose 'IMAGE' for image-only output, or "
+                    "'IMAGE+TEXT' to return both the generated image and a text response.",
+                    advanced=True,
+                ),
+                IO.Autogrow.Input(
+                    "images",
+                    template=autogrow_template,
+                    optional=True,
+                    tooltip="Optional image UUIDs to use as context for the model.",
+                ),
+                IO.String.Input(
+                    "system_prompt",
+                    multiline=True,
+                    default=GEMINI_IMAGE_SYS_PROMPT,
+                    optional=True,
+                    tooltip="Foundational instructions that dictate an AI's behavior.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="image_uuid"),
+                IO.String.Output(display_name="text"),
+            ],
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        model: str,
+        aspect_ratio: str,
+        resolution: str,
+        response_modalities: str,
+        images: IO.Autogrow.Type | None = None,
+        system_prompt: str = "",
+    ) -> IO.NodeOutput:
+        prompt = validate_string(prompt, strip_whitespace=True, min_length=1)
+
+        parts: list[GeminiPart] = [GeminiPart(text=prompt)]
+        if images is not None:
+            parts.extend(await create_image_parts(cls, images))
+
+        image_config = GeminiImageConfig(imageSize=resolution)
+        if aspect_ratio != "auto":
+            image_config.aspectRatio = aspect_ratio
+
+        gemini_system_prompt = None
+        if system_prompt:
+            gemini_system_prompt = GeminiSystemInstructionContent(parts=[GeminiTextPart(text=system_prompt)], role=None)
+
+        token = get_vertex_ai_access_token()
+
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(
+                path=f"{GEMINI_BASE_ENDPOINT}/{model}:generateContent", 
+                method="POST", 
+                headers={"Authorization": f"Bearer {token}"}
+            ),
+            data=GeminiImageGenerateContentRequest(
+                contents=[
+                    GeminiContent(role=GeminiRole.user, parts=parts),
+                ],
+                generationConfig=GeminiImageGenerationConfig(
+                    responseModalities=(["IMAGE"] if response_modalities == "IMAGE" else ["TEXT", "IMAGE"]),
+                    imageConfig=image_config,
+                ),
+                systemInstruction=gemini_system_prompt,
+            ),
+            response_model=GeminiGenerateContentResponse,
+            price_extractor=calculate_tokens_price,
+        )
+
+        return IO.NodeOutput(await upload_images_and_get_uuids(cls, response), get_text_from_response(response))

--- a/template-service/backend_template/engine/main.py
+++ b/template-service/backend_template/engine/main.py
@@ -1,12 +1,22 @@
 import asyncio
-from comfy_api_nodes.nodes_gemini import GeminiNodeAmplify
+from comfy_api_nodes.nodes_gemini import GeminiImageNode, GeminiImage2Node
+from comfy_api_nodes.util.client import sync_op
+from comfy_api_nodes.util import ApiEndpoint
+from comfy_api_nodes.apis.gemini import GeminiPart, GeminiInlineData, GeminiImageGenerateContentRequest, GeminiContent
+from comfy_api.latest import IO
+from config import gemini_config, media_ingest_config
+import base64
+import uuid
+import io
 
 async def main():
-    response = await GeminiNodeAmplify.execute(
-        prompt="Hello, how are you?", 
-        model="gemini-2.5-flash", 
-        system_prompt="You are a helpful assistant.",
-        images={"image1": "019cc840-0d81-7689-a3cf-f836d09231d9", "image2": "019cc840-9720-768f-9af8-5ba15054b19d"}
+    response = await GeminiImage2Node.execute(
+        prompt="make a image of a cat", 
+        model="gemini-2.5-flash-image",
+        aspect_ratio="16:9",
+        resolution="1K",
+        response_modalities="IMAGE",
+        # images={"image_uuid0": "019cc840-0d81-7689-a3cf-f836d09231d9"}
     )
     # The output format depends on NodeOutput, typically indexable or with dictionary keys.
     print(response.result)


### PR DESCRIPTION
Integrated Nanobana and Nanobana 2. 
The nodes hook the response from Vertex AI directly to the Media Ingest API utilizing an asyncio-to-thread requests pool to bypass Windows chunking bugs, returning a deterministic UUID mediaId string for the frontend.
Closes #190 