### PR TITLE
AMPLIFY-208: Add GET full node catalog endpoint

### DIFF
--- a/template-service/backend_template/config.py
+++ b/template-service/backend_template/config.py
@@ -11,6 +11,9 @@ class Config(BaseSettings):
     description: str = "Generative AI Workflow Template Management"
     environment: str = "development"
 
+    # Engine Settings
+    engine_base_url: str = "http://localhost:8188"
+
     # Database Settings
     postgres_dsn: str
     postgres_echo: bool = False

--- a/template-service/backend_template/engine/app/logger.py
+++ b/template-service/backend_template/engine/app/logger.py
@@ -1,0 +1,15 @@
+import logging
+
+_initialized = False
+
+def setup_logger(log_level='INFO'):
+    global _initialized
+    if _initialized:
+        return
+    _initialized = True
+    
+    logger = logging.getLogger()
+    logger.setLevel(log_level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)

--- a/template-service/backend_template/engine/comfy/model_management.py
+++ b/template-service/backend_template/engine/comfy/model_management.py
@@ -1,12 +1,27 @@
 import threading
 
+class InterruptProcessingException(Exception):
+    pass
+
 interrupt_processing_mutex = threading.RLock()
 
 interrupt_processing = False
-
+def interrupt_current_processing(value=True):
+    global interrupt_processing
+    global interrupt_processing_mutex
+    with interrupt_processing_mutex:
+        interrupt_processing = value
+        
 def processing_interrupted():
     global interrupt_processing
     global interrupt_processing_mutex
     with interrupt_processing_mutex:
         return interrupt_processing
-    
+
+def throw_exception_if_processing_interrupted():
+    global interrupt_processing
+    global interrupt_processing_mutex
+    with interrupt_processing_mutex:
+        if interrupt_processing:
+            interrupt_processing = False
+            raise InterruptProcessingException()    

--- a/template-service/backend_template/engine/comfy_api/internal/__init__.py
+++ b/template-service/backend_template/engine/comfy_api/internal/__init__.py
@@ -1,3 +1,9 @@
+from .api_registry import (
+    ComfyAPIBase as ComfyAPIBase,
+    ComfyAPIWithVersion as ComfyAPIWithVersion,
+    register_versions as register_versions,
+    get_all_versions as get_all_versions,
+)
 
 from typing import Callable, Optional
 
@@ -24,6 +30,14 @@ def first_real_override(cls: type, name: str, *, base: type=None) -> Optional[Ca
             if func is not base_func:         # real override
                 return getattr(cls, name)     # bound to *cls*
     return None
+
+class _ComfyNodeInternal:
+    """Class that all V3-based APIs inherit from for ComfyNode.
+
+    This is intended to only be referenced within execution.py, as it has to handle all V3 APIs going forward."""
+    @classmethod
+    def GET_NODE_INFO_V1(cls):
+        ...
 
 class _NodeOutputInternal:
     """Class that all V3-based APIs inherit from for NodeOutput.

--- a/template-service/backend_template/engine/comfy_api/internal/api_registry.py
+++ b/template-service/backend_template/engine/comfy_api/internal/api_registry.py
@@ -1,0 +1,39 @@
+from typing import NamedTuple
+from comfy_api.internal.singleton import ProxiedSingleton
+from packaging import version as packaging_version
+
+
+class ComfyAPIBase(ProxiedSingleton):
+    def __init__(self):
+        pass
+
+
+class ComfyAPIWithVersion(NamedTuple):
+    version: str
+    api_class: type[ComfyAPIBase]
+
+
+def parse_version(version_str: str) -> packaging_version.Version:
+    """
+    Parses a version string into a packaging_version.Version object.
+    Raises ValueError if the version string is invalid.
+    """
+    if version_str == "latest":
+        return packaging_version.parse("9999999.9999999.9999999")
+    return packaging_version.parse(version_str)
+
+
+registered_versions: list[ComfyAPIWithVersion] = []
+
+
+def register_versions(versions: list[ComfyAPIWithVersion]):
+    versions.sort(key=lambda x: parse_version(x.version))
+    global registered_versions
+    registered_versions = versions
+
+
+def get_all_versions() -> list[ComfyAPIWithVersion]:
+    """
+    Returns a list of all registered ComfyAPI versions.
+    """
+    return registered_versions

--- a/template-service/backend_template/engine/comfy_api/internal/singleton.py
+++ b/template-service/backend_template/engine/comfy_api/internal/singleton.py
@@ -1,0 +1,33 @@
+from typing import TypeVar
+
+class SingletonMetaclass(type):
+    T = TypeVar("T", bound="SingletonMetaclass")
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(SingletonMetaclass, cls).__call__(
+                *args, **kwargs
+            )
+        return cls._instances[cls]
+
+    def inject_instance(cls: type[T], instance: T) -> None:
+        assert cls not in SingletonMetaclass._instances, (
+            "Cannot inject instance after first instantiation"
+        )
+        SingletonMetaclass._instances[cls] = instance
+
+    def get_instance(cls: type[T], *args, **kwargs) -> T:
+        """
+        Gets the singleton instance of the class, creating it if it doesn't exist.
+        """
+        if cls not in SingletonMetaclass._instances:
+            SingletonMetaclass._instances[cls] = super(
+                SingletonMetaclass, cls
+            ).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class ProxiedSingleton(object, metaclass=SingletonMetaclass):
+    def __init__(self):
+        super().__init__()

--- a/template-service/backend_template/engine/comfy_api/latest/__init__.py
+++ b/template-service/backend_template/engine/comfy_api/latest/__init__.py
@@ -1,5 +1,13 @@
 from . import _io_public as io
+from comfy_api.internal import ComfyAPIBase
 from abc import ABC, abstractmethod
+
+class ComfyAPI_latest(ComfyAPIBase):
+    VERSION = "latest"
+    STABLE = False
+
+    def __init__(self):
+        super().__init__()
 
 class ComfyExtension(ABC):
     async def on_load(self) -> None:
@@ -14,10 +22,13 @@ class ComfyExtension(ABC):
         Returns a list of nodes that this extension provides.
         """
 
+ComfyAPI = ComfyAPI_latest
+
 IO = io
 
 __all__ = [
-    "io",
+    "ComfyAPI",
+    "io",   
     "IO",
     "ComfyExtension",
 ]

--- a/template-service/backend_template/engine/comfy_api/latest/_io.py
+++ b/template-service/backend_template/engine/comfy_api/latest/_io.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+import copy
 import inspect
 from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, TypeVar, TypedDict, Literal
-from typing import final
+from typing import Any, TypeVar, TypedDict, Literal, Callable
+from typing_extensions import final
 
-from comfy_api.internal import (copy_class, prune_dict, _NodeOutputInternal, is_class, shallow_clone_class, first_real_override, classproperty, ExecutionBlocker)
+from comfy_api.internal import (copy_class, prune_dict, _NodeOutputInternal, is_class, shallow_clone_class, first_real_override, classproperty, ExecutionBlocker, _ComfyNodeInternal)
 
 
 class RemoteOptions:
@@ -138,9 +140,10 @@ class WidgetInput(Input):
     '''
     Base class for a V3 Input with widget.
     '''
-    def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None, default: Any=None,
-                 socketless: bool=None, widget_type: str=None, force_input: bool=None, extra_dict=None, advanced: bool=None):
-        super().__init__(id, display_name, optional, tooltip, extra_dict, advanced)
+    def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None,
+                 default: Any=None, socketless: bool=None, widget_type: str=None, force_input: bool=None,
+                 extra_dict=None, raw_link: bool=None, advanced: bool=None):
+        super().__init__(id, display_name, optional, tooltip, lazy, extra_dict, raw_link, advanced)
         self.default = default
         self.socketless = socketless
         self.widget_type = widget_type
@@ -159,16 +162,18 @@ class WidgetInput(Input):
 
 
 class Output(_IO_V3):
-    def __init__(self, id: str=None, display_name: str=None, tooltip: str=None):
+    def __init__(self, id: str=None, display_name: str=None, tooltip: str=None, is_output_list: bool=False):
         self.id = id
         self.display_name = display_name if display_name else id
         self.tooltip = tooltip
+        self.is_output_list = is_output_list
 
     def as_dict(self):
         display_name = self.display_name if self.display_name else self.id
         return prune_dict({
             "display_name": display_name,
             "tooltip": self.tooltip,
+            "is_output_list": self.is_output_list,
         })
 
     def get_io_type(self):
@@ -193,7 +198,7 @@ class Boolean(ComfyTypeIO):
         '''Boolean input.'''
         def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None, default: bool=None, label_on: str=None, label_off: str=None,
                     socketless: bool=None, force_input: bool=None, extra_dict=None, advanced: bool=None):
-            super().__init__(id, display_name, optional, tooltip, default, socketless, None, force_input, extra_dict, advanced)
+            super().__init__(id, display_name, optional, tooltip, None, default, socketless, None, force_input, extra_dict, None, advanced)
             self.label_on = label_on
             self.label_off = label_off
             self.default: bool
@@ -213,7 +218,7 @@ class Int(ComfyTypeIO):
         def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None,
                     default: int=None, min: int=None, max: int=None, step: int=None, control_after_generate: bool=None,
                     display_mode: NumberDisplay=None, socketless: bool=None, force_input: bool=None, extra_dict=None, advanced: bool=None):
-            super().__init__(id, display_name, optional, tooltip, default, socketless, None, force_input, extra_dict, advanced)
+            super().__init__(id, display_name, optional, tooltip, None, default, socketless, None, force_input, extra_dict, None, advanced)
             self.min = min
             self.max = max
             self.step = step
@@ -265,7 +270,7 @@ class String(ComfyTypeIO):
         def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None,
                     multiline=False, placeholder: str=None, default: str=None, dynamic_prompts: bool=None,
                     socketless: bool=None, force_input: bool=None, extra_dict=None, advanced: bool=None):
-            super().__init__(id, display_name, optional, tooltip, default, socketless, None, force_input, extra_dict, advanced)
+            super().__init__(id, display_name, optional, tooltip, None, default, socketless, None, force_input, extra_dict, None, advanced)
             self.multiline = multiline
             self.placeholder = placeholder
             self.dynamic_prompts = dynamic_prompts
@@ -301,7 +306,7 @@ class Combo(ComfyTypeIO):
                 options = [v.value for v in options]
             if isinstance(default, Enum):
                 default = default.value
-            super().__init__(id, display_name, optional, tooltip, default, socketless, None, None, extra_dict, advanced)
+            super().__init__(id, display_name, optional, tooltip, None, default, socketless, None, None, extra_dict, None, advanced)
             self.multiselect = False
             self.options = options
             self.remote = remote
@@ -311,8 +316,6 @@ class Combo(ComfyTypeIO):
             return super().as_dict() | prune_dict({
                 "multiselect": self.multiselect,
                 "options": self.options,
-                **({self.upload.value: True} if self.upload is not None else {}),
-                "image_folder": self.image_folder.value if self.image_folder else None,
                 "remote": self.remote.as_dict() if self.remote else None,
             })
 
@@ -324,7 +327,186 @@ class Combo(ComfyTypeIO):
 @comfytype(io_type="IMAGE")
 class Image(ComfyTypeIO):
     Type = str
+
+class DynamicInput(Input, ABC):
+    '''
+    Abstract class for dynamic input registration.
+    '''
+    pass
+
+
+class DynamicOutput(Output, ABC):
+    '''
+    Abstract class for dynamic output registration.
+    '''
+    pass
+
+def handle_prefix(prefix_list: list[str] | None, id: str | None = None) -> list[str]:
+    if prefix_list is None:
+        prefix_list = []
+    if id is not None:
+        prefix_list = prefix_list + [id]
+    return prefix_list
+
+def finalize_prefix(prefix_list: list[str] | None, id: str | None = None) -> str:
+    assert not (prefix_list is None and id is None)
+    if prefix_list is None:
+        return id
+    elif id is not None:
+        prefix_list = prefix_list + [id]
+    return ".".join(prefix_list)
+
+@comfytype(io_type="COMFY_AUTOGROW_V3")
+class Autogrow(ComfyTypeI):
+    Type = dict[str, Any]
+    _MaxNames = 100  # NOTE: max 100 names for sanity
+
+    class _AutogrowTemplate:
+        def __init__(self, input: Input):
+            # dynamic inputs are not allowed as the template input
+            assert(not isinstance(input, DynamicInput))
+            self.input = copy.copy(input)
+            if isinstance(self.input, WidgetInput):
+                self.input.force_input = True
+            self.names: list[str] = []
+            self.cached_inputs = {}
+
+        def _create_input(self, input: Input, name: str):
+            new_input = copy.copy(self.input)
+            new_input.id = name
+            return new_input
+
+        def _create_cached_inputs(self):
+            for name in self.names:
+                self.cached_inputs[name] = self._create_input(self.input, name)
+
+        def get_all(self) -> list[Input]:
+            return list(self.cached_inputs.values())
+
+        def as_dict(self):
+            return prune_dict({
+                "input": create_input_dict_v1([self.input]),
+            })
+
+        def validate(self):
+            self.input.validate()
+
+    class TemplatePrefix(_AutogrowTemplate):
+        def __init__(self, input: Input, prefix: str, min: int=1, max: int=10):
+            super().__init__(input)
+            self.prefix = prefix
+            assert(min >= 0)
+            assert(max >= 1)
+            assert(max <= Autogrow._MaxNames)
+            self.min = min
+            self.max = max
+            self.names = [f"{self.prefix}{i}" for i in range(self.max)]
+            self._create_cached_inputs()
+
+        def as_dict(self):
+            return super().as_dict() | prune_dict({
+                "prefix": self.prefix,
+                "min": self.min,
+                "max": self.max,
+            })
+
+    class TemplateNames(_AutogrowTemplate):
+        def __init__(self, input: Input, names: list[str], min: int=1):
+            super().__init__(input)
+            self.names = names[:Autogrow._MaxNames]
+            assert(min >= 0)
+            self.min = min
+            self._create_cached_inputs()
+
+        def as_dict(self):
+            return super().as_dict() | prune_dict({
+                "names": self.names,
+                "min": self.min,
+            })
+
+    class Input(DynamicInput):
+        def __init__(self, id: str, template: Autogrow.TemplatePrefix | Autogrow.TemplateNames,
+                     display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None, extra_dict=None):
+            super().__init__(id, display_name, optional, tooltip, lazy, extra_dict)
+            self.template = template
+
+        def as_dict(self):
+            return super().as_dict() | prune_dict({
+                "template": self.template.as_dict(),
+            })
+
+        def get_all(self) -> list[Input]:
+            return [self] + self.template.get_all()
+
+        def validate(self):
+            self.template.validate()
+
+    @staticmethod
+    def _expand_schema_for_dynamic(out_dict: dict[str, Any], live_inputs: dict[str, Any], value: tuple[str, dict[str, Any]], input_type: str, curr_prefix: list[str] | None):
+        # NOTE: purposely do not include self in out_dict; instead use only the template inputs
+        # need to figure out names based on template type
+        is_names = ("names" in value[1]["template"])
+        is_prefix = ("prefix" in value[1]["template"])
+        input = value[1]["template"]["input"]
+        if is_names:
+            min = value[1]["template"]["min"]
+            names = value[1]["template"]["names"]
+            max = len(names)
+        elif is_prefix:
+            prefix = value[1]["template"]["prefix"]
+            min = value[1]["template"]["min"]
+            max = value[1]["template"]["max"]
+            names = [f"{prefix}{i}" for i in range(max)]
+        # need to create a new input based on the contents of input
+        template_input = None
+        template_required = True
+        for _input_type, dict_input in input.items():
+            # for now, get just the first value from dict_input; if not required, min can be ignored
+            if len(dict_input) == 0:
+                continue
+            template_input = list(dict_input.values())[0]
+            template_required = _input_type == "required"
+            break
+        if template_input is None:
+            raise Exception("template_input could not be determined from required or optional; this should never happen.")
+        new_dict = {}
+        new_dict_added_to = False
+        # first, add possible inputs into out_dict
+        for i, name in enumerate(names):
+            expected_id = finalize_prefix(curr_prefix, name)
+            # required
+            if i < min and template_required:
+                out_dict["required"][expected_id] = template_input
+                type_dict = new_dict.setdefault("required", {})
+            # optional
+            else:
+                out_dict["optional"][expected_id] = template_input
+                type_dict = new_dict.setdefault("optional", {})
+            if expected_id in live_inputs:
+                # NOTE: prefix gets added in parse_class_inputs
+                type_dict[name] = template_input
+                new_dict_added_to = True
+        # account for the edge case that all inputs are optional and no values are received
+        if not new_dict_added_to:
+            finalized_prefix = finalize_prefix(curr_prefix)
+            out_dict["dynamic_paths"][finalized_prefix] = finalized_prefix
+            out_dict["dynamic_paths_default_value"][finalized_prefix] = DynamicPathsDefaultValue.EMPTY_DICT
+        parse_class_inputs(out_dict, live_inputs, new_dict, curr_prefix)
+
+DYNAMIC_INPUT_LOOKUP: dict[str, Callable[[dict[str, Any], dict[str, Any], tuple[str, dict[str, Any]], str, list[str] | None], None]] = {}
+def register_dynamic_input_func(io_type: str, func: Callable[[dict[str, Any], dict[str, Any], tuple[str, dict[str, Any]], str, list[str] | None], None]):
+    DYNAMIC_INPUT_LOOKUP[io_type] = func
+
+def get_dynamic_input_func(io_type: str) -> Callable[[dict[str, Any], dict[str, Any], tuple[str, dict[str, Any]], str, list[str] | None], None]:
+    return DYNAMIC_INPUT_LOOKUP[io_type]
+
+def setup_dynamic_input_funcs():
+    # Autogrow.Input
+    register_dynamic_input_func(Autogrow.io_type, Autogrow._expand_schema_for_dynamic)
     
+if len(DYNAMIC_INPUT_LOOKUP) == 0:
+    setup_dynamic_input_funcs()
+
 class V3Data(TypedDict):
     hidden_inputs: dict[str, Any]
     'Dictionary where the keys are the hidden input ids and the values are the values of the hidden inputs.'
@@ -363,6 +545,30 @@ class Hidden(str, Enum):
     """UNIQUE_ID is the unique identifier of the node, and matches the id property of the node on the client side. It is commonly used in client-server communications (see messages)."""
     prompt = "PROMPT"
     """PROMPT is the complete prompt sent by the client to the server. See the prompt object for a full description."""
+
+@dataclass
+class NodeInfoV1:
+    input: dict=None
+    input_order: dict[str, list[str]]=None
+    is_input_list: bool=None
+    output: list[str]=None
+    output_is_list: list[bool]=None
+    output_name: list[str]=None
+    output_tooltips: list[str]=None
+    output_matchtypes: list[str]=None
+    name: str=None
+    display_name: str=None
+    description: str=None
+    python_module: Any=None
+    category: str=None
+    output_node: bool=None
+    deprecated: bool=None
+    experimental: bool=None
+    dev_only: bool=None
+    api_node: bool=None
+    price_badge: dict | None = None
+    search_aliases: list[str]=None
+    essentials_category: str=None
 
 @dataclass
 class NodeInfoV3:
@@ -440,10 +646,18 @@ class Schema:
     outputs: list[Output] = field(default_factory=list)
     hidden: list[Hidden] = field(default_factory=list)
     description: str=""
+    search_aliases: list[str] = field(default_factory=list)
+    is_input_list: bool = False
     is_output_node: bool=False
-
+    is_deprecated: bool=False
+    is_experimental: bool=False
+    is_dev_only: bool=False
     is_api_node: bool=False
     price_badge: PriceBadge | None = None
+    not_idempotent: bool=False
+    enable_expand: bool=False
+    accept_all_inputs: bool=False
+    essentials_category: str | None = None
 
     def validate(self):
         '''Validate the schema:
@@ -496,6 +710,61 @@ class Schema:
             if output.id is None:
                 output.id = f"_{i}_{output.io_type}_"
 
+    def get_v1_info(self, cls) -> NodeInfoV1:
+        # get V1 inputs
+        input = create_input_dict_v1(self.inputs)
+        if self.hidden:
+            for hidden in self.hidden:
+                input.setdefault("hidden", {})[hidden.name] = (hidden.value,)
+        # create separate lists from output fields
+        output = []
+        output_is_list = []
+        output_name = []
+        output_tooltips = []
+        output_matchtypes = []
+        any_matchtypes = False
+        if self.outputs:
+            for o in self.outputs:
+                output.append(o.io_type)
+                output_is_list.append(o.is_output_list)
+                output_name.append(o.display_name if o.display_name else o.io_type)
+                output_tooltips.append(o.tooltip if o.tooltip else None)
+                # # special handling for MatchType
+                # if isinstance(o, MatchType.Output):
+                #     output_matchtypes.append(o.template.template_id)
+                #     any_matchtypes = True
+                # else:
+                #     output_matchtypes.append(None)
+
+        # clear out lists that are all None
+        if not any_matchtypes:
+            output_matchtypes = None
+
+        info = NodeInfoV1(
+            input=input,
+            input_order={key: list(value.keys()) for (key, value) in input.items()},
+            is_input_list=self.is_input_list,
+            output=output,
+            output_is_list=output_is_list,
+            output_name=output_name,
+            output_tooltips=output_tooltips,
+            output_matchtypes=output_matchtypes,
+            name=self.node_id,
+            display_name=self.display_name,
+            category=self.category,
+            description=self.description,
+            output_node=self.is_output_node,
+            deprecated=self.is_deprecated,
+            experimental=self.is_experimental,
+            dev_only=self.is_dev_only,
+            api_node=self.is_api_node,
+            python_module=getattr(cls, "RELATIVE_PYTHON_MODULE", "nodes"),
+            price_badge=self.price_badge.as_dict(self.inputs) if self.price_badge is not None else None,
+            search_aliases=self.search_aliases if self.search_aliases else None,
+            essentials_category=self.essentials_category,
+        )
+        return info
+
     def get_v3_info(self) -> NodeInfoV3:
         input_dict = {}
         output_dict = {}
@@ -524,13 +793,45 @@ class Schema:
             price_badge=self.price_badge.as_dict(self.inputs) if self.price_badge is not None else None,
         )
         return info 
-    
+
+def parse_class_inputs(out_dict: dict[str, Any], live_inputs: dict[str, Any], curr_dict: dict[str, Any], curr_prefix: list[str] | None=None) -> None:
+    for input_type, inner_d in curr_dict.items():
+        for id, value in inner_d.items():
+            io_type = value[0]
+            if io_type in DYNAMIC_INPUT_LOOKUP:
+                # dynamic inputs need to be handled with lookup functions
+                dynamic_input_func = get_dynamic_input_func(io_type)
+                new_prefix = handle_prefix(curr_prefix, id)
+                dynamic_input_func(out_dict, live_inputs, value, input_type, new_prefix)
+            else:
+                # non-dynamic inputs get directly transferred
+                finalized_id = finalize_prefix(curr_prefix, id)
+                out_dict[input_type][finalized_id] = value
+                if curr_prefix:
+                    out_dict["dynamic_paths"][finalized_id] = finalized_id
+
+def create_input_dict_v1(inputs: list[Input]) -> dict:
+    input = {
+        "required": {}
+    }
+    for i in inputs:
+        add_to_dict_v1(i, input)
+    return input
+
+def add_to_dict_v1(i: Input, d: dict):
+    key = "optional" if i.optional else "required"
+    as_dict = i.as_dict()
+    # for v1, we don't want to include the optional key
+    as_dict.pop("optional", None)
+    d.setdefault(key, {})[i.id] = (i.get_io_type(), as_dict)
+
 def add_to_dict_v3(io: Input | Output, d: dict):
     d[io.id] = (io.get_io_type(), io.as_dict())           
 
-class _ComfyNodeBaseInternal():
+class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     """Common base class for storing internal methods and properties; DO NOT USE for defining nodes."""
 
+    RELATIVE_PYTHON_MODULE = None
     SCHEMA = None
 
     # filled in during execution
@@ -623,13 +924,135 @@ class _ComfyNodeBaseInternal():
         type_clone.hidden = HiddenHolder.from_v3_data(v3_data)
         return type_clone
 
+    #############################################
+    # V1 Backwards Compatibility code
+    #--------------------------------------------
     @final
     @classmethod
-    def GET_NODE_INFO_V3(cls) -> dict[str, Any]:
+    def GET_NODE_INFO_V1(cls) -> dict[str, Any]:
         schema = cls.GET_SCHEMA()
-        info = schema.get_v3_info(cls)
+        info = schema.get_v1_info(cls)
         return asdict(info)
-    
+
+    _DESCRIPTION = None
+    @final
+    @classproperty
+    def DESCRIPTION(cls):  # noqa
+        if cls._DESCRIPTION is None:
+            cls.GET_SCHEMA()
+        return cls._DESCRIPTION
+
+    _CATEGORY = None
+    @final
+    @classproperty
+    def CATEGORY(cls):  # noqa
+        if cls._CATEGORY is None:
+            cls.GET_SCHEMA()
+        return cls._CATEGORY
+
+    _EXPERIMENTAL = None
+    @final
+    @classproperty
+    def EXPERIMENTAL(cls):  # noqa
+        if cls._EXPERIMENTAL is None:
+            cls.GET_SCHEMA()
+        return cls._EXPERIMENTAL
+
+    _DEPRECATED = None
+    @final
+    @classproperty
+    def DEPRECATED(cls):  # noqa
+        if cls._DEPRECATED is None:
+            cls.GET_SCHEMA()
+        return cls._DEPRECATED
+
+    _DEV_ONLY = None
+    @final
+    @classproperty
+    def DEV_ONLY(cls):  # noqa
+        if cls._DEV_ONLY is None:
+            cls.GET_SCHEMA()
+        return cls._DEV_ONLY
+
+    _API_NODE = None
+    @final
+    @classproperty
+    def API_NODE(cls):  # noqa
+        if cls._API_NODE is None:
+            cls.GET_SCHEMA()
+        return cls._API_NODE
+
+    _OUTPUT_NODE = None
+    @final
+    @classproperty
+    def OUTPUT_NODE(cls):  # noqa
+        if cls._OUTPUT_NODE is None:
+            cls.GET_SCHEMA()
+        return cls._OUTPUT_NODE
+
+    _INPUT_IS_LIST = None
+    @final
+    @classproperty
+    def INPUT_IS_LIST(cls):  # noqa
+        if cls._INPUT_IS_LIST is None:
+            cls.GET_SCHEMA()
+        return cls._INPUT_IS_LIST
+    _OUTPUT_IS_LIST = None
+
+    @final
+    @classproperty
+    def OUTPUT_IS_LIST(cls):  # noqa
+        if cls._OUTPUT_IS_LIST is None:
+            cls.GET_SCHEMA()
+        return cls._OUTPUT_IS_LIST
+
+    _RETURN_TYPES = None
+    @final
+    @classproperty
+    def RETURN_TYPES(cls):  # noqa
+        if cls._RETURN_TYPES is None:
+            cls.GET_SCHEMA()
+        return cls._RETURN_TYPES
+
+    _RETURN_NAMES = None
+    @final
+    @classproperty
+    def RETURN_NAMES(cls):  # noqa
+        if cls._RETURN_NAMES is None:
+            cls.GET_SCHEMA()
+        return cls._RETURN_NAMES
+
+    _OUTPUT_TOOLTIPS = None
+    @final
+    @classproperty
+    def OUTPUT_TOOLTIPS(cls):  # noqa
+        if cls._OUTPUT_TOOLTIPS is None:
+            cls.GET_SCHEMA()
+        return cls._OUTPUT_TOOLTIPS
+
+    _NOT_IDEMPOTENT = None
+    @final
+    @classproperty
+    def NOT_IDEMPOTENT(cls):  # noqa
+        if cls._NOT_IDEMPOTENT is None:
+            cls.GET_SCHEMA()
+        return cls._NOT_IDEMPOTENT
+
+    _ACCEPT_ALL_INPUTS = None
+    @final
+    @classproperty
+    def ACCEPT_ALL_INPUTS(cls):  # noqa
+        if cls._ACCEPT_ALL_INPUTS is None:
+            cls.GET_SCHEMA()
+        return cls._ACCEPT_ALL_INPUTS
+
+    @final
+    @classmethod
+    def INPUT_TYPES(cls) -> dict[str, dict]:
+        schema = cls.FINALIZE_SCHEMA()
+        info = schema.get_v1_info(cls)
+        return info.input
+
     @final
     @classmethod
     def FINALIZE_SCHEMA(cls):
@@ -637,7 +1060,7 @@ class _ComfyNodeBaseInternal():
         schema = cls.define_schema()
         schema.finalize()
         return schema
-    
+
     @final
     @classmethod
     def GET_SCHEMA(cls) -> Schema:
@@ -645,9 +1068,47 @@ class _ComfyNodeBaseInternal():
         cls.VALIDATE_CLASS()
         schema = cls.FINALIZE_SCHEMA()
         schema.validate()
-        
+        if cls._DESCRIPTION is None:
+            cls._DESCRIPTION = schema.description
+        if cls._CATEGORY is None:
+            cls._CATEGORY = schema.category
+        if cls._EXPERIMENTAL is None:
+            cls._EXPERIMENTAL = schema.is_experimental
+        if cls._DEPRECATED is None:
+            cls._DEPRECATED = schema.is_deprecated
+        if cls._DEV_ONLY is None:
+            cls._DEV_ONLY = schema.is_dev_only
+        if cls._API_NODE is None:
+            cls._API_NODE = schema.is_api_node
+        if cls._OUTPUT_NODE is None:
+            cls._OUTPUT_NODE = schema.is_output_node
+        if cls._INPUT_IS_LIST is None:
+            cls._INPUT_IS_LIST = schema.is_input_list
+        if cls._NOT_IDEMPOTENT is None:
+            cls._NOT_IDEMPOTENT = schema.not_idempotent
+        if cls._ACCEPT_ALL_INPUTS is None:
+            cls._ACCEPT_ALL_INPUTS = schema.accept_all_inputs
+
+        if cls._RETURN_TYPES is None:
+            output = []
+            output_name = []
+            output_is_list = []
+            output_tooltips = []
+            if schema.outputs:
+                for o in schema.outputs:
+                    output.append(o.io_type)
+                    output_name.append(o.display_name if o.display_name else o.io_type)
+                    output_is_list.append(o.is_output_list)
+                    output_tooltips.append(o.tooltip if o.tooltip else None)
+
+            cls._RETURN_TYPES = output
+            cls._RETURN_NAMES = output_name
+            cls._OUTPUT_IS_LIST = output_is_list
+            cls._OUTPUT_TOOLTIPS = output_tooltips
         cls.SCHEMA = schema
         return schema
+    #--------------------------------------------
+    #############################################
 
 class ComfyNode(_ComfyNodeBaseInternal):
     """Common base class for all V3 nodes."""

--- a/template-service/backend_template/engine/comfy_api/version_list.py
+++ b/template-service/backend_template/engine/comfy_api/version_list.py
@@ -1,0 +1,6 @@
+from comfy_api.latest import ComfyAPI_latest
+from comfy_api.internal import ComfyAPIBase
+
+supported_versions: list[type[ComfyAPIBase]] = [
+    ComfyAPI_latest,
+]

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
@@ -624,6 +624,6 @@ class GeminiExtension(ComfyExtension):
         ]
 
 
-async def comfy_entrypoint() -> VeoExtension:
-    return VeoExtension()
+async def comfy_entrypoint() -> GeminiExtension:
+    return GeminiExtension()
     

--- a/template-service/backend_template/engine/config.py
+++ b/template-service/backend_template/engine/config.py
@@ -12,5 +12,15 @@ class GeminiConfig(ConfigBase):
 class MediaIngestConfig(ConfigBase):
     media_ingest_url: str = "http://localhost:5070/media/api"
 
+class EngineConfig(ConfigBase):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore", env_prefix="ENGINE_")
+    listen: str = "127.0.0.1"
+    port: int = 8188
+    verbose: bool = True              
+    temp_directory: str | None = None  
+    log_level: str = "INFO"            
+    log_stdout: bool = False           
+
 gemini_config = GeminiConfig()
 media_ingest_config = MediaIngestConfig()
+engine_config = EngineConfig()

--- a/template-service/backend_template/engine/main.py
+++ b/template-service/backend_template/engine/main.py
@@ -1,36 +1,79 @@
+import os
+import folder_paths
+from app.logger import setup_logger
+import logging
+import sys
+
+from config import engine_config
+
+setup_logger(log_level=engine_config.log_level)
+
+# Main code
 import asyncio
-from comfy_api_nodes.nodes_gemini import GeminiImageNode, GeminiImage2Node, GeminiNode
-from comfy_api_nodes.nodes_veo2 import VeoVideoGenerationNode, Veo3FirstLastFrameNode
-from comfy_api_nodes.util.client import sync_op
-from comfy_api_nodes.util import ApiEndpoint
-from comfy_api_nodes.apis.gemini import GeminiPart, GeminiInlineData, GeminiImageGenerateContentRequest, GeminiContent
-from comfy_api.latest import IO
-from config import gemini_config, media_ingest_config
-import base64
-import uuid
-import io
-from comfy_api_nodes.util import get_vertex_ai_access_token, fetch_media_uri_from_ingest, register_media_uri_with_ingest
+import shutil
 
-async def main():
-    # Test register_media_uri_with_ingest
-    # media_id = await register_media_uri_with_ingest(VeoVideoGenerationNode, "gs://amplify-media-test/5519547473301993309/sample_0.mp4", "video/mp4")
-    # print(media_id)
+import server
+import nodes
+import app.logger
 
-    response = await Veo3FirstLastFrameNode.execute(
-        prompt="generate a video of a lambo urus", 
-        model="veo-3.1-fast-generate",
-        resolution="1080p",
-        first_frame_uuid="019cdcf2-7327-7577-9061-2074fb03797b",
-        last_frame_uuid="019cdcf2-f636-7275-aee2-8037ac70b564",
-        negative_prompt="",
-        aspect_ratio="9:16",
-        duration=4,
-        seed=0,
-        generate_audio=True,
-    )   
-    # # The output format depends on NodeOutput, typically indexable or with dictionary keys.
-    print(response.result)
-    print(response[0])
+
+async def run(server_instance, address='', port=8188, verbose=True, call_on_start=None):
+    addresses = []
+    for addr in address.split(","):
+        addresses.append((addr, port))
+    await server_instance.start_multi_address(addresses, call_on_start, verbose)
+    await asyncio.Event().wait()
+    # await asyncio.gather(
+    #     server_instance.start_multi_address(addresses, call_on_start, verbose), server_instance.publish_loop()
+    # )
+
+def cleanup_temp():
+    temp_dir = folder_paths.get_temp_directory()
+    if os.path.exists(temp_dir):
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+def start_comfyui(asyncio_loop=None):
+    """
+    Starts the ComfyUI server using the provided asyncio event loop or creates a new one.
+    Returns the event loop, server instance, and a function to start the server asynchronously.
+    """
+    if engine_config.temp_directory:
+        temp_dir = os.path.join(os.path.abspath(engine_config.temp_directory), "temp")
+        logging.info(f"Setting temp directory to: {temp_dir}")
+        folder_paths.set_temp_directory(temp_dir)
+    cleanup_temp()
+
+    if not asyncio_loop:
+        asyncio_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(asyncio_loop)
+    prompt_server = server.PromptServer(asyncio_loop)
+
+    asyncio_loop.run_until_complete(nodes.init_extra_nodes())
+
+    prompt_server.add_routes()
+
+    os.makedirs(folder_paths.get_temp_directory(), exist_ok=True)
+
+    async def start_all():
+        await prompt_server.setup()
+        await run(prompt_server, address=engine_config.listen, port=engine_config.port, verbose=engine_config.verbose, call_on_start=None)
+ 
+    # Returning these so that other code can integrate with the ComfyUI loop and server
+    return asyncio_loop, prompt_server, start_all
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # Running directly, just start ComfyUI.
+    logging.info("Python version: {}".format(sys.version))
+
+    if sys.version_info.major == 3 and sys.version_info.minor < 10:
+        logging.warning("WARNING: You are using a python version older than 3.10, please upgrade to a newer one. 3.12 and above is recommended.")
+
+    event_loop, _, start_all_func = start_comfyui()
+    try:
+        x = start_all_func()
+        event_loop.run_until_complete(x)
+    except KeyboardInterrupt:
+        logging.info("\nStopped server")
+
+    cleanup_temp()

--- a/template-service/backend_template/engine/nodes.py
+++ b/template-service/backend_template/engine/nodes.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import sys
+import glob
+import inspect
+
+import traceback
+import logging
+
+import comfy.utils
+from comfy_api.internal import register_versions, ComfyAPIWithVersion
+from comfy_api.version_list import supported_versions
+from comfy_api.latest import io, ComfyExtension
+
+import comfy.model_management
+
+import importlib
+
+def before_node_execution():
+    comfy.model_management.throw_exception_if_processing_interrupted()
+
+def interrupt_processing(value=True):
+    comfy.model_management.interrupt_current_processing(value)
+
+NODE_CLASS_MAPPINGS = {
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+}
+
+EXTENSION_WEB_DIRS = {}
+
+# Dictionary of successfully loaded module names and associated directories.
+LOADED_MODULE_DIRS = {}
+
+
+def get_module_name(module_path: str) -> str:
+    """
+    Returns the module name based on the given module path.
+    Examples:
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node.py") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__.py") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__/") -> "my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node.disabled") -> "custom_nodes
+    Args:
+        module_path (str): The path of the module.
+    Returns:
+        str: The module name.
+    """
+    base_path = os.path.basename(module_path)
+    if os.path.isfile(module_path):
+        base_path = os.path.splitext(base_path)[0]
+    return base_path
+
+
+async def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes") -> bool:
+    module_name = get_module_name(module_path)
+    if os.path.isfile(module_path):
+        sp = os.path.splitext(module_path)
+        module_name = sp[0]
+        sys_module_name = module_name
+    elif os.path.isdir(module_path):
+        sys_module_name = module_path.replace(".", "_x_")
+
+    try:
+        logging.debug("Trying to load custom node {}".format(module_path))
+        if os.path.isfile(module_path):
+            module_spec = importlib.util.spec_from_file_location(sys_module_name, module_path)
+            module_dir = os.path.split(module_path)[0]
+        else:
+            module_spec = importlib.util.spec_from_file_location(sys_module_name, os.path.join(module_path, "__init__.py"))
+            module_dir = module_path
+
+        module = importlib.util.module_from_spec(module_spec)
+        sys.modules[sys_module_name] = module
+        module_spec.loader.exec_module(module)
+
+        LOADED_MODULE_DIRS[module_name] = os.path.abspath(module_dir)
+
+        # V3 Extension Definition
+        if hasattr(module, "comfy_entrypoint"):
+            entrypoint = getattr(module, "comfy_entrypoint")
+            if not callable(entrypoint):
+                logging.warning(f"comfy_entrypoint in {module_path} is not callable, skipping.")
+                return False
+            try:
+                if inspect.iscoroutinefunction(entrypoint):
+                    extension = await entrypoint()
+                else:
+                    extension = entrypoint()
+                if not isinstance(extension, ComfyExtension):
+                    logging.warning(f"comfy_entrypoint in {module_path} did not return a ComfyExtension, skipping.")
+                    return False
+                await extension.on_load()
+                node_list = await extension.get_node_list()
+                if not isinstance(node_list, list):
+                    logging.warning(f"comfy_entrypoint in {module_path} did not return a list of nodes, skipping.")
+                    return False
+                for node_cls in node_list:
+                    node_cls: io.ComfyNode
+                    schema = node_cls.GET_SCHEMA()
+                    if schema.node_id not in ignore:
+                        NODE_CLASS_MAPPINGS[schema.node_id] = node_cls
+                        node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
+                    if schema.display_name is not None:
+                        NODE_DISPLAY_NAME_MAPPINGS[schema.node_id] = schema.display_name
+                return True
+            except Exception as e:
+                logging.warning(f"Error while calling comfy_entrypoint in {module_path}: {e}")
+                return False
+        else:
+            logging.warning(f"Skip {module_path} module for custom nodes due to the lack of NODE_CLASS_MAPPINGS or NODES_LIST (need one).")
+            return False
+    except Exception as e:
+        logging.warning(traceback.format_exc())
+        logging.warning(f"Cannot import {module_path} module for custom nodes: {e}")
+        return False
+
+async def init_builtin_api_nodes():
+    api_nodes_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_api_nodes")
+    api_nodes_files = sorted(glob.glob(os.path.join(api_nodes_dir, "nodes_*.py")))
+
+    import_failed = []
+    for node_file in api_nodes_files:
+        if not await load_custom_node(node_file, module_parent="comfy_api_nodes"):
+            import_failed.append(os.path.basename(node_file))
+
+    return import_failed
+
+async def init_public_apis():
+    register_versions([
+        ComfyAPIWithVersion(
+            version=getattr(v, "VERSION"),
+            api_class=v
+        ) for v in supported_versions
+    ])
+
+async def init_extra_nodes(init_api_nodes=True):
+    await init_public_apis()
+
+    if init_api_nodes:
+        import_failed_api = await init_builtin_api_nodes()
+
+        if len(import_failed_api) > 0:
+            logging.warning("WARNING: some comfy_api_nodes/ nodes did not import correctly. This may be because they are missing some dependencies.\n")
+            for node in import_failed_api:
+                logging.warning("IMPORT FAILED: {}".format(node))
+            logging.warning("")

--- a/template-service/backend_template/engine/server.py
+++ b/template-service/backend_template/engine/server.py
@@ -1,0 +1,139 @@
+import asyncio
+
+import nodes
+
+import aiohttp
+from aiohttp import web
+import logging
+
+from comfy_api.internal import _ComfyNodeInternal
+
+from typing import Optional
+
+
+class PromptServer():
+    def __init__(self, loop):
+        PromptServer.instance = self
+
+        # self.prompt_queue = execution.PromptQueue(self)
+        self.loop = loop
+        self.messages = asyncio.Queue()
+        self.client_session:Optional[aiohttp.ClientSession] = None
+        self.number = 0
+
+        self.app = web.Application()
+        self.sockets = dict()
+        self.sockets_metadata = dict()
+
+        routes = web.RouteTableDef()
+        self.routes = routes
+        self.last_node_id = None
+        self.client_id = None
+
+        self.on_prompt_handlers = []
+
+
+        def node_info(node_class):
+            obj_class = nodes.NODE_CLASS_MAPPINGS[node_class]
+            if issubclass(obj_class, _ComfyNodeInternal):
+                return obj_class.GET_NODE_INFO_V1()
+            info = {}
+            info['input'] = obj_class.INPUT_TYPES()
+            info['input_order'] = {key: list(value.keys()) for (key, value) in obj_class.INPUT_TYPES().items()}
+            info['is_input_list'] = getattr(obj_class, "INPUT_IS_LIST", False)
+            info['output'] = obj_class.RETURN_TYPES
+            info['output_is_list'] = obj_class.OUTPUT_IS_LIST if hasattr(obj_class, 'OUTPUT_IS_LIST') else [False] * len(obj_class.RETURN_TYPES)
+            info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']
+            info['name'] = node_class
+            info['display_name'] = nodes.NODE_DISPLAY_NAME_MAPPINGS[node_class] if node_class in nodes.NODE_DISPLAY_NAME_MAPPINGS.keys() else node_class
+            info['description'] = obj_class.DESCRIPTION if hasattr(obj_class,'DESCRIPTION') else ''
+            info['python_module'] = getattr(obj_class, "RELATIVE_PYTHON_MODULE", "nodes")
+            info['category'] = 'sd'
+            if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
+                info['output_node'] = True
+            else:
+                info['output_node'] = False
+
+            if hasattr(obj_class, 'CATEGORY'):
+                info['category'] = obj_class.CATEGORY
+
+            if hasattr(obj_class, 'OUTPUT_TOOLTIPS'):
+                info['output_tooltips'] = obj_class.OUTPUT_TOOLTIPS
+
+            if getattr(obj_class, "DEPRECATED", False):
+                info['deprecated'] = True
+            if getattr(obj_class, "EXPERIMENTAL", False):
+                info['experimental'] = True
+            if getattr(obj_class, "DEV_ONLY", False):
+                info['dev_only'] = True
+
+            if hasattr(obj_class, 'API_NODE'):
+                info['api_node'] = obj_class.API_NODE
+
+            info['search_aliases'] = getattr(obj_class, 'SEARCH_ALIASES', [])
+
+            if hasattr(obj_class, 'ESSENTIALS_CATEGORY'):
+                info['essentials_category'] = obj_class.ESSENTIALS_CATEGORY
+
+            return info
+
+        @routes.get("/object_info")
+        async def get_object_info(request):
+            out = {}
+            for x in nodes.NODE_CLASS_MAPPINGS:
+                try:
+                    out[x] = node_info(x)
+                except Exception:
+                    logging.error(f"[ERROR] An error occurred while retrieving information for the '{x}' node.", exc_info=True)
+            return web.json_response(out)
+
+        @routes.get("/object_info/{node_class}")
+        async def get_object_info_node(request):
+            node_class = request.match_info.get("node_class", None)
+            out = {}
+            if (node_class is not None) and (node_class in nodes.NODE_CLASS_MAPPINGS):
+                out[node_class] = node_info(node_class)
+            return web.json_response(out)
+
+
+    async def setup(self):
+        timeout = aiohttp.ClientTimeout(total=None) # no timeout
+        self.client_session = aiohttp.ClientSession(timeout=timeout)
+
+    def add_routes(self):
+        
+        api_routes = web.RouteTableDef()
+        for route in self.routes:
+            # Custom nodes might add extra static routes. Only process non-static
+            # routes to add /api prefix.
+            if isinstance(route, web.RouteDef):
+                api_routes.route(route.method, "/api" + route.path)(route.handler, **route.kwargs)
+        self.app.add_routes(api_routes)
+        self.app.add_routes(self.routes)
+
+    async def start_multi_address(self, addresses, call_on_start=None, verbose=True):
+        runner = web.AppRunner(self.app, access_log=None)
+        await runner.setup()
+
+        if verbose:
+            logging.info("Starting server\n")
+        for addr in addresses:
+            address = addr[0]
+            port = addr[1]
+            site = web.TCPSite(runner, address, port)
+            await site.start()
+
+            if not hasattr(self, 'address'):
+                self.address = address
+                self.port = port
+
+            if ':' in address:
+                address_print = "[{}]".format(address)
+            else:
+                address_print = address
+
+            if verbose:
+                logging.info("Listening on: http://{}:{}".format(address_print, port))
+
+        if call_on_start is not None:
+            call_on_start("http", self.address, self.port)

--- a/template-service/backend_template/services/engine_client.py
+++ b/template-service/backend_template/services/engine_client.py
@@ -1,0 +1,38 @@
+import aiohttp
+from fastapi import HTTPException, status
+
+from backend_template.config import settings
+
+
+class EngineClientService:
+    """
+    Async HTTP client for the engine.
+    Proxies requests from the FastAPI gateway to the internal aiohttp engine.
+    """
+
+    async def get_all_node_info(self) -> dict:
+        """Proxy GET /api/object_info → all registered node schemas."""
+        return await self._get(f"{settings.engine_base_url}/api/object_info")
+
+    async def get_node_info(self, node_class: str) -> dict:
+        """Proxy GET /api/object_info/{node_class} → single node schema."""
+        return await self._get(
+            f"{settings.engine_base_url}/api/object_info/{node_class}"
+        )
+
+    async def _get(self, url: str) -> dict:
+        """Shared GET helper with connection error handling."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url, timeout=aiohttp.ClientTimeout(total=10)
+                ) as resp:
+                    if resp.status >= 400:
+                        text = await resp.text()
+                        raise HTTPException(status_code=resp.status, detail=text)
+                    return await resp.json()
+        except aiohttp.ClientConnectorError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Engine is not available",
+            )

--- a/template-service/backend_template/web/app.py
+++ b/template-service/backend_template/web/app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
-from backend_template.web.routes.http.v1 import project_template
+from backend_template.web.routes.http.v1 import project_template, engine
 
 app = FastAPI(title="Template Service")
 
 app.include_router(project_template.router, prefix="/v1")
+app.include_router(engine.router, prefix="/v1")
 
 @app.get("/health")
 async def health_check():

--- a/template-service/backend_template/web/routes/http/v1/engine.py
+++ b/template-service/backend_template/web/routes/http/v1/engine.py
@@ -1,0 +1,40 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+
+from backend_template.services.engine_client import EngineClientService
+
+router = APIRouter(prefix="/engine", tags=["Engine"])
+
+Service = Annotated[EngineClientService, Depends(EngineClientService)]
+
+
+@router.get(
+    "/nodes",
+    status_code=status.HTTP_200_OK,
+    summary="Get all node schemas",
+)
+async def get_all_nodes(
+    service: Service,
+):
+    """
+    Returns the full schema (inputs, outputs, metadata) for every
+    registered node in the engine.
+    """
+    return await service.get_all_node_info()
+
+
+@router.get(
+    "/nodes/{node_class}",
+    status_code=status.HTTP_200_OK,
+    summary="Get a single node schema",
+)
+async def get_node(
+    node_class: str,
+    service: Service,
+):
+    """
+    Returns the schema for a specific node class by name
+    (e.g., `GeminiNode`, `VeoVideoGenerationNode`).
+    """
+    return await service.get_node_info(node_class)

--- a/template-service/poetry.lock
+++ b/template-service/poetry.lock
@@ -1274,6 +1274,18 @@ files = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
+    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 description = "Accelerated property cache"
@@ -2422,4 +2434,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "25a9524a2baf7278136422473b84a07ba80aa2c47283c1eeb4d3bf926e5dd0c7"
+content-hash = "c6875875ae6a66ac32312dd70db31b70c5f81ecf6235a9bf58e60588bf92db23"

--- a/template-service/pyproject.toml
+++ b/template-service/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "psycopg2-binary (>=2.9.11,<3.0.0)",
     "aiohttp (>=3.13.3,<4.0.0)",
     "google-auth (>=2.48.0,<3.0.0)",
-    "requests (>=2.32.5,<3.0.0)"
+    "requests (>=2.32.5,<3.0.0)",
+    "packaging (>=26.0,<27.0)"
 ]
 
 [tool.poetry]

--- a/template-service/scripts/entrypoint.sh
+++ b/template-service/scripts/entrypoint.sh
@@ -8,7 +8,11 @@ set -e
 echo "Running Database Migrations..."
 alembic upgrade head
 
-# 2. Start the Application
+# 2. Start Engine
+echo "Starting Engine on port 8188..."
+python backend_template/engine/main.py &
+
+# 3. Start FastAPI Gateway (foreground, public port)
 exec uvicorn backend_template.web.app:app \
     --host 0.0.0.0 \
     --port 8000 \


### PR DESCRIPTION
## Summary

Implements the `GET /v1/engine/nodes` endpoint that returns the full node catalog
from the internal ComfyUI engine, enabling clients to discover available nodes
and their input/output schemas.

Closes #208

## What was done

### FastAPI Gateway Layer
- **New route** `GET /v1/engine/nodes` — returns all registered node schemas
- **New route** `GET /v1/engine/nodes/{node_class}` — returns a single node schema
- **New service** [EngineClientService](cci:2://file:///c:/Users/WA1/Amplify/template-service/backend_template/services/engine_client.py:6:0-37:13) — proxies requests to the engine via `aiohttp`
  (no new dependencies, `aiohttp` is already used by the engine)
- Returns `503 Service Unavailable` if the engine is not reachable

### Engine Skeleton
- Added core engine modules: [server.py](cci:7://file:///c:/Users/WA1/Amplify/template-service/backend_template/engine/server.py:0:0-0:0), `nodes.py`, `app/logger.py`
- Added `comfy_api` schema layer: V1/V3 node info, API registry, version management
- Replaced ComfyUI CLI argument parsing with Pydantic [EngineConfig](cci:2://file:///c:/Users/WA1/Amplify/template-service/backend_template/engine/config.py:14:0-21:28)
- Added `ENGINE_` env prefix to avoid collision with gateway's `PORT` variable

### Infrastructure
- Engine launches as a background process in [entrypoint.sh](cci:7://file:///c:/Users/WA1/Amplify/template-service/scripts/entrypoint.sh:0:0-0:0) on port 8188
- Fixed CRLF → LF line endings in [entrypoint.sh](cci:7://file:///c:/Users/WA1/Amplify/template-service/scripts/entrypoint.sh:0:0-0:0) for Linux containers
- Added `engine_base_url` to gateway [Config](cci:2://file:///c:/Users/WA1/Amplify/template-service/backend_template/config.py:6:0-45:20) (defaults to `http://localhost:8188`)
- Added `packaging` dependency, regenerated `poetry.lock`
- Updated `api-specs/template-service.json`

## How to test

1. `docker-compose up --build`
2. Open Swagger UI at `http://localhost:8000/docs`
3. Try `GET /v1/engine/nodes` → should return all node schemas
4. Try `GET /v1/engine/nodes/GeminiNode` → should return single node schema
