### PR TITLE
AMPLIFY-267: Multi-image Node

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -102,6 +102,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -583,6 +584,7 @@
       "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.94.1.tgz",
       "integrity": "sha512-WffyHMzsB8uVrzVxjK+0zII0msuqLL5JOGaZsWQzRvoZQJsJcGe9+kUaBNKPVDupcghHncSRJCdcC5ZcCdy/sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.7.2",
         "@hey-api/json-schema-ref-parser": "1.3.1",
@@ -5018,6 +5020,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5028,6 +5031,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5083,6 +5087,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -5632,6 +5637,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5933,6 +5939,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -5955,6 +5962,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -6029,6 +6037,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6455,6 +6464,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7017,6 +7027,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7202,6 +7213,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11144,6 +11156,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11153,6 +11166,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11179,6 +11193,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12187,6 +12202,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12399,6 +12415,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12935,6 +12952,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+// =============================================================================
+// AssetDetailPage — Full view of a single generated asset
+// =============================================================================
+
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   ArrowLeft,
   ImageIcon,
@@ -13,9 +17,18 @@ import {
   Loader2,
   ExternalLink,
   Clock,
+  LayoutTemplate,
+  CalendarDays,
+  TrendingUp,
+  Eye,
+  Users,
+  Heart,
+  Download,
+  Sparkles,
 } from "lucide-react";
 import { ProjectHeader } from "@/components/ProjectHeader";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useProjects } from "@/features/ambassadors/hooks/useProjects";
 import { projectApi } from "@/features/ambassadors/services/api";
 import type { ProjectAsset, PublicationRecord } from "@/features/ambassadors/types";
@@ -23,6 +36,10 @@ import { getTemplateV1TemplatesTemplateIdGet } from "@/lib/api/template-service"
 import { useHubConnection } from "@/hooks/useHubConnection";
 
 type TemplateMeta = { id: string; name: string } | null | undefined;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function statusColor(status: string) {
   switch (status.toLowerCase()) {
@@ -38,6 +55,29 @@ function statusColor(status: string) {
       return "bg-white/10 text-white/70 border-white/20";
   }
 }
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Social provider icon
+// ---------------------------------------------------------------------------
 
 function ProviderIcon({ provider, size = 4 }: { provider: string; size?: number }) {
   const cls = `w-${size} h-${size} fill-current`;
@@ -56,47 +96,70 @@ function ProviderIcon({ provider, size = 4 }: { provider: string; size?: number 
       </svg>
     );
   }
-  return <span className="text-xs text-white/60">{provider}</span>;
+  return <span className="text-xs text-white/60">{provider[0].toUpperCase()}</span>;
 }
 
-function formatTime(iso: string) {
-  return new Date(iso).toLocaleString(undefined, {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+// ---------------------------------------------------------------------------
+// Analytics stat card
+// ---------------------------------------------------------------------------
 
-function PublicationCard({
-  rec,
-  thumbnailUrl,
+function StatCard({
+  icon,
+  label,
+  value,
+  sub,
+  accent,
 }: {
-  rec: PublicationRecord;
-  thumbnailUrl: string;
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+  accent?: string;
 }) {
+  return (
+    <div className={cn(
+      "flex-1 rounded-xl border border-white/[0.07] bg-white/[0.03] px-4 py-4",
+      "hover:border-white/[0.12] transition-colors duration-200"
+    )}>
+      <div className="flex items-center gap-2 mb-3">
+        <div className={cn("w-7 h-7 rounded-lg flex items-center justify-center", accent ?? "bg-white/[0.07]")}>
+          {icon}
+        </div>
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-white/30">{label}</span>
+      </div>
+      <p className="text-2xl font-bold text-white/85 tracking-tight">{value}</p>
+      {sub && <p className="text-[10px] text-white/25 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Publication card (social post)
+// ---------------------------------------------------------------------------
+
+function PublicationCard({ rec, thumbnailUrl }: { rec: PublicationRecord; thumbnailUrl: string }) {
   const statusLow = rec.status.toLowerCase();
   const isPublished = statusLow === "published";
   const timeLabel = isPublished && rec.publishedAt
     ? formatTime(rec.publishedAt)
     : rec.scheduledAt
-    ? formatTime(rec.scheduledAt)
-    : null;
+      ? formatTime(rec.scheduledAt)
+      : null;
 
   const inner = (
-    <div className="relative rounded-xl overflow-hidden bg-muted/40 aspect-[9/16] group cursor-pointer">
-      <img
-        src={thumbnailUrl}
-        alt="publication thumbnail"
-        className="w-full h-full object-cover"
-      />
-
-      {/* Gradient overlay */}
+    <div className={cn(
+      "relative rounded-xl overflow-hidden bg-black/40 aspect-[9/16] group cursor-pointer",
+      "border border-white/[0.06] hover:border-white/[0.15]",
+      "transition-all duration-200"
+    )}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={thumbnailUrl} alt="" className="w-full h-full object-cover" />
       <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
 
       {/* Top-left: avatar */}
       <div className="absolute top-2.5 left-2.5">
         {rec.socialAccount?.avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
           <img
             src={rec.socialAccount.avatarUrl}
             alt={rec.socialAccount.username}
@@ -104,7 +167,7 @@ function PublicationCard({
           />
         ) : (
           <div className="w-7 h-7 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center ring-1 ring-white/30">
-            <span className="text-[10px] font-semibold text-white">
+            <span className="text-[10px] font-bold text-white">
               {rec.socialAccount?.username?.[0]?.toUpperCase() ?? "?"}
             </span>
           </div>
@@ -116,29 +179,25 @@ function PublicationCard({
         <ProviderIcon provider={rec.provider} size={5} />
       </div>
 
-      {/* Bottom: username + time + status */}
+      {/* Bottom: info */}
       <div className="absolute bottom-0 left-0 right-0 px-3 pb-3 space-y-1.5">
         <p className="text-white text-xs font-medium truncate leading-none">
           @{rec.socialAccount?.username ?? rec.provider}
         </p>
-
         {timeLabel && (
-          <div className="flex items-center gap-1 text-white/60 text-[10px]">
+          <div className="flex items-center gap-1 text-white/50 text-[10px]">
             <Clock className="w-2.5 h-2.5 shrink-0" />
             {timeLabel}
           </div>
         )}
-
-        <span
-          className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${statusColor(rec.status)}`}
-        >
+        <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold border ${statusColor(rec.status)}`}>
           {rec.status}
         </span>
       </div>
 
-      {/* Hover: view post hint */}
+      {/* Hover overlay */}
       {isPublished && rec.publicUrl && (
-        <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+        <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
           <div className="flex items-center gap-1.5 text-white text-xs font-medium">
             <ExternalLink className="w-3.5 h-3.5" />
             View post
@@ -149,15 +208,32 @@ function PublicationCard({
   );
 
   if (isPublished && rec.publicUrl) {
-    return (
-      <a href={rec.publicUrl} target="_blank" rel="noopener noreferrer">
-        {inner}
-      </a>
-    );
+    return <a href={rec.publicUrl} target="_blank" rel="noopener noreferrer">{inner}</a>;
   }
-
   return inner;
 }
+
+// ---------------------------------------------------------------------------
+// Metadata row item
+// ---------------------------------------------------------------------------
+
+function MetaRow({ icon, label, children }: { icon: React.ReactNode; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-3 py-3 border-b border-white/[0.05] last:border-0">
+      <div className="w-7 h-7 rounded-md bg-white/[0.05] flex items-center justify-center shrink-0 mt-0.5">
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-white/25 mb-0.5">{label}</p>
+        <div className="text-sm text-white/75">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 
 export default function AssetDetailPage() {
   const params = useParams();
@@ -173,21 +249,17 @@ export default function AssetDetailPage() {
   const [records, setRecords] = useState<PublicationRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
   const [videoPlaying, setVideoPlaying] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     if (!assetId) return;
-
     setLoading(true);
     setError(null);
 
-    projectApi
-      .getProjectAsset(assetId)
+    projectApi.getProjectAsset(assetId)
       .then(async (fetchedAsset) => {
         setAsset(fetchedAsset);
-
         const [templateResult, recordsResult] = await Promise.allSettled([
           fetchedAsset.templateId
             ? getTemplateV1TemplatesTemplateIdGet({ path: { template_id: fetchedAsset.templateId } })
@@ -210,15 +282,10 @@ export default function AssetDetailPage() {
       .finally(() => setLoading(false));
   }, [assetId]);
 
-  // Live status updates via SignalR
+  // Live SignalR status updates
   useEffect(() => {
     if (!connection) return;
-
-    const handler = (
-      publicationRecordId: string,
-      status: string,
-      publicUrl: string | null,
-    ) => {
+    const handler = (publicationRecordId: string, status: string, publicUrl: string | null) => {
       setRecords((prev) =>
         prev.map((r) =>
           r.id === publicationRecordId
@@ -227,46 +294,56 @@ export default function AssetDetailPage() {
         )
       );
     };
-
     connection.on("OnPublicationStatusChanged", handler);
     return () => connection.off("OnPublicationStatusChanged", handler);
   }, [connection]);
 
   const isVideo = asset?.mediaType === "Video";
+  const publishedCount = records.filter((r) => r.status.toLowerCase() === "published").length;
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-[oklch(0.09_0.02_264)]">
       <ProjectHeader projects={projects} isLoading={projectsLoading} />
 
-      <div className="container mx-auto px-6 py-8 max-w-5xl">
+      <div className="container mx-auto px-6 py-8 max-w-6xl">
+        {/* Back */}
         <button
           onClick={() => router.push(`/projects/${projectId}/assets`)}
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+          className="flex items-center gap-1.5 text-sm text-white/30 hover:text-white/70 transition-colors mb-7 group"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="w-3.5 h-3.5 transition-transform group-hover:-translate-x-0.5" />
           Back to Assets
         </button>
 
+        {/* Loading */}
         {loading && (
           <div className="flex items-center justify-center py-32">
-            <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+            <Loader2 className="w-7 h-7 animate-spin text-white/20" />
           </div>
         )}
 
+        {/* Error */}
         {error && (
-          <div className="text-center py-20 text-destructive">{error}</div>
+          <div className="text-center py-20 text-red-400/60 text-sm">{error}</div>
         )}
 
+        {/* Content */}
         {!loading && !error && asset && (
           <motion.div
-            initial={{ opacity: 0, y: 12 }}
+            initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="space-y-8"
+            transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+            className="space-y-10"
           >
-            {/* Top: media preview + details */}
-            <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
-              <div className="lg:col-span-3 space-y-4">
-                <div className="relative rounded-2xl overflow-hidden bg-muted/40 aspect-video flex items-center justify-center">
+            {/* ── Hero + Metadata ── */}
+            <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+              {/* Left: Media */}
+              <div className="lg:col-span-3 space-y-3">
+                <div className={cn(
+                  "relative rounded-2xl overflow-hidden bg-black/50",
+                  "border border-white/[0.07]",
+                  isVideo ? "aspect-video" : "aspect-video"
+                )}>
                   {isVideo ? (
                     <>
                       <video
@@ -278,111 +355,193 @@ export default function AssetDetailPage() {
                         controls={videoPlaying}
                         onEnded={() => setVideoPlaying(false)}
                       />
-                      {!videoPlaying && (
-                        <button
-                          onClick={() => {
-                            setVideoPlaying(true);
-                            videoRef.current?.play();
-                          }}
-                          className="absolute inset-0 flex items-center justify-center group"
-                        >
-                          <div className="w-16 h-16 rounded-full bg-black/60 backdrop-blur-sm flex items-center justify-center group-hover:bg-black/80 transition-colors">
-                            <Play className="w-7 h-7 text-white ml-1" />
-                          </div>
-                        </button>
-                      )}
+                      <AnimatePresence>
+                        {!videoPlaying && (
+                          <motion.button
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            onClick={() => { setVideoPlaying(true); videoRef.current?.play(); }}
+                            className="absolute inset-0 flex items-center justify-center group"
+                          >
+                            <div className="w-16 h-16 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 flex items-center justify-center group-hover:bg-black/80 group-hover:scale-110 transition-all duration-200">
+                              <Play className="w-6 h-6 text-white ml-0.5" />
+                            </div>
+                          </motion.button>
+                        )}
+                      </AnimatePresence>
                     </>
                   ) : (
-                    <img
-                      src={asset.mediaUrl}
-                      alt="Generated asset"
-                      className="w-full h-full object-contain"
-                    />
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={asset.mediaUrl} alt="Generated asset" className="w-full h-full object-contain" />
                   )}
 
-                  <div className="absolute top-3 left-3 flex items-center gap-1 px-2 py-0.5 rounded-full bg-black/60 text-white text-xs font-medium backdrop-blur-sm">
-                    {isVideo
-                      ? <><Video className="w-3 h-3" /> Video</>
-                      : <><ImageIcon className="w-3 h-3" /> Image</>
-                    }
+                  {/* Type badge */}
+                  <div className={cn(
+                    "absolute top-3 left-3 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold backdrop-blur-sm",
+                    isVideo
+                      ? "bg-red-500/20 text-red-300 border border-red-500/30"
+                      : "bg-[#ec4899]/15 text-[#ec4899] border border-[#ec4899]/30"
+                  )}>
+                    {isVideo ? <Video className="w-2.5 h-2.5" /> : <ImageIcon className="w-2.5 h-2.5" />}
+                    {isVideo ? "Video" : "Image"}
                   </div>
                 </div>
 
-                <a
-                  href={asset.mediaUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                  Open original
-                </a>
+                {/* Download / open */}
+                <div className="flex items-center gap-3">
+                  <a
+                    href={asset.mediaUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 text-xs text-white/30 hover:text-white/60 transition-colors"
+                  >
+                    <ExternalLink className="w-3.5 h-3.5" />
+                    Open original
+                  </a>
+                  <a
+                    href={asset.mediaUrl}
+                    download
+                    className="flex items-center gap-1.5 text-xs text-white/30 hover:text-white/60 transition-colors"
+                  >
+                    <Download className="w-3.5 h-3.5" />
+                    Download
+                  </a>
+                </div>
               </div>
 
-              <div className="lg:col-span-2 space-y-3">
-                <h2 className="text-lg font-semibold">Details</h2>
-                <div className="rounded-xl border border-border/50 divide-y divide-border/50 text-sm">
-                  <div className="flex items-center justify-between px-4 py-3">
-                    <span className="text-muted-foreground">Created</span>
-                    <span>
-                      {new Date(asset.createdAt).toLocaleDateString(undefined, {
-                        day: "2-digit",
-                        month: "short",
-                        year: "numeric",
-                      })}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between px-4 py-3">
-                    <span className="text-muted-foreground">Template</span>
-                    {template === null ? (
-                      <span className="text-muted-foreground italic flex items-center gap-1">
+              {/* Right: Metadata */}
+              <div className="lg:col-span-2">
+                <div className="rounded-2xl border border-white/[0.07] bg-white/[0.02] px-4 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-white/20 pt-2 pb-1">
+                    Asset Details
+                  </p>
+
+                  <MetaRow
+                    icon={<CalendarDays className="w-3.5 h-3.5 text-white/40" />}
+                    label="Generated"
+                  >
+                    {formatDateTime(asset.createdAt)}
+                  </MetaRow>
+
+                  <MetaRow
+                    icon={<LayoutTemplate className="w-3.5 h-3.5 text-white/40" />}
+                    label="Template"
+                  >
+                    {template === undefined ? (
+                      <Loader2 className="w-3.5 h-3.5 animate-spin text-white/30" />
+                    ) : template === null ? (
+                      <span className="text-white/25 flex items-center gap-1">
                         <FileQuestion className="w-3.5 h-3.5" />
                         Not found
                       </span>
-                    ) : template === undefined ? (
-                      <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
                     ) : (
                       <button
-                        onClick={() =>
-                          router.push(`/projects/${projectId}/templates/${template.id}`)
-                        }
-                        className="text-primary hover:underline truncate max-w-[160px]"
+                        onClick={() => router.push(`/projects/${projectId}/templates/${template.id}`)}
+                        className="text-[#ec4899]/80 hover:text-[#ec4899] hover:underline flex items-center gap-1 transition-colors"
                       >
                         {template.name}
+                        <ChevronRight className="w-3 h-3" />
                       </button>
                     )}
-                  </div>
+                  </MetaRow>
+
+                  <MetaRow
+                    icon={<Sparkles className="w-3.5 h-3.5 text-white/40" />}
+                    label="Type"
+                  >
+                    {asset.mediaType}
+                  </MetaRow>
+
+                  <MetaRow
+                    icon={<Send className="w-3.5 h-3.5 text-white/40" />}
+                    label="Publications"
+                  >
+                    <span className={publishedCount > 0 ? "text-emerald-400" : "text-white/40"}>
+                      {publishedCount} published
+                    </span>
+                    {records.length > publishedCount && (
+                      <span className="text-white/25 ml-1.5">/ {records.length} total</span>
+                    )}
+                  </MetaRow>
                 </div>
               </div>
             </div>
 
-            {/* Publications grid */}
-            <div className="space-y-4">
-              <h2 className="text-lg font-semibold">Publications</h2>
+            {/* ── Analytics row (stub — ready for real data) ── */}
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <TrendingUp className="w-4 h-4 text-white/25" />
+                <h2 className="text-sm font-semibold uppercase tracking-widest text-white/30">
+                  Analytics
+                </h2>
+                <span className="ml-1 text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-white/[0.06] text-white/25 border border-white/[0.06]">
+                  Coming soon
+                </span>
+              </div>
+              <div className="flex gap-4">
+                <StatCard
+                  icon={<Eye className="w-3.5 h-3.5 text-blue-400/70" />}
+                  label="Total Views"
+                  value="—"
+                  sub="Across all platforms"
+                  accent="bg-blue-500/10"
+                />
+                <StatCard
+                  icon={<Users className="w-3.5 h-3.5 text-violet-400/70" />}
+                  label="Reach"
+                  value="—"
+                  sub="Unique accounts"
+                  accent="bg-violet-500/10"
+                />
+                <StatCard
+                  icon={<Heart className="w-3.5 h-3.5 text-[#ec4899]/70" />}
+                  label="Engagement"
+                  value="—"
+                  sub="Likes + comments"
+                  accent="bg-[#ec4899]/10"
+                />
+                <StatCard
+                  icon={<TrendingUp className="w-3.5 h-3.5 text-emerald-400/70" />}
+                  label="Publications"
+                  value={String(records.length)}
+                  sub={`${publishedCount} live`}
+                  accent="bg-emerald-500/10"
+                />
+              </div>
+            </div>
+
+            {/* ── Publications ── */}
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Send className="w-4 h-4 text-white/25" />
+                <h2 className="text-sm font-semibold uppercase tracking-widest text-white/30">
+                  Publications
+                </h2>
+                {records.length > 0 && (
+                  <span className="ml-1 text-[9px] font-mono text-white/20">
+                    {records.length}
+                  </span>
+                )}
+              </div>
 
               {records.length === 0 ? (
-                <div className="rounded-xl border border-dashed border-border/60 px-5 py-12 flex flex-col items-center gap-3 text-center">
-                  <div className="w-10 h-10 rounded-full bg-muted/60 flex items-center justify-center">
-                    <Send className="w-4 h-4 text-muted-foreground" />
+                <div className={cn(
+                  "rounded-2xl border border-dashed border-white/[0.08] px-6 py-14",
+                  "flex flex-col items-center gap-3 text-center"
+                )}>
+                  <div className="w-10 h-10 rounded-full bg-white/[0.05] border border-white/[0.08] flex items-center justify-center">
+                    <Send className="w-4 h-4 text-white/25" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium">No publications yet</p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Share this asset to social media.
-                    </p>
+                    <p className="text-sm font-medium text-white/40">No publications yet</p>
+                    <p className="text-xs text-white/20 mt-0.5">Share this asset to social media to see it here.</p>
                   </div>
-                  <Button size="sm" variant="outline" disabled>
-                    Create your first publication
-                  </Button>
                 </div>
               ) : (
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                   {records.map((rec) => (
-                    <PublicationCard
-                      key={rec.id}
-                      rec={rec}
-                      thumbnailUrl={asset.mediaUrl}
-                    />
+                    <PublicationCard key={rec.id} rec={rec} thumbnailUrl={asset.mediaUrl} />
                   ))}
                 </div>
               )}
@@ -393,3 +552,5 @@ export default function AssetDetailPage() {
     </div>
   );
 }
+
+

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
@@ -303,7 +303,7 @@ export default function AssetDetailPage() {
   const publishedCount = records.filter((r) => r.status.toLowerCase() === "published").length;
 
   return (
-    <div className="min-h-screen bg-[oklch(0.09_0.02_264)]">
+    <div className="min-h-screen bg-background">
       <ProjectHeader projects={projects} isLoading={projectsLoading} />
 
       <div className="container mx-auto px-6 py-8 max-w-6xl">

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
@@ -25,6 +25,7 @@ import {
   Heart,
   Download,
   Sparkles,
+  ChevronRight,
 } from "lucide-react";
 import { ProjectHeader } from "@/components/ProjectHeader";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
@@ -1,37 +1,95 @@
 "use client";
 
+// =============================================================================
+// AssetsPage — Time-grouped grid of all final generated assets
+// =============================================================================
+
+import { useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ImageIcon, Video, Loader2, PackageOpen } from "lucide-react";
+import {
+  ImageIcon,
+  Video,
+  Loader2,
+  Sparkles,
+  ChevronRight,
+} from "lucide-react";
 import { ProjectHeader } from "@/components/ProjectHeader";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useProjects } from "@/features/ambassadors/hooks/useProjects";
 import { useProjectAssets } from "@/features/ambassadors/hooks/useProjectAssets";
 import type { ProjectAsset } from "@/features/ambassadors/types";
 
+// ---------------------------------------------------------------------------
+// Time-group helpers
+// ---------------------------------------------------------------------------
+
+function getGroup(dateStr: string): string {
+  const now = new Date();
+  const d = new Date(dateStr);
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
+  const week7Start = new Date(todayStart.getTime() - 6 * 86_400_000);
+  const month30Start = new Date(todayStart.getTime() - 29 * 86_400_000);
+
+  if (d >= todayStart) return "Today";
+  if (d >= yesterdayStart) return "Yesterday";
+  if (d >= week7Start) return "Previous 7 days";
+  if (d >= month30Start) return "This month";
+  return "Older";
+}
+
+const GROUP_ORDER = ["Today", "Yesterday", "Previous 7 days", "This month", "Older"];
+
+function groupAssets(assets: ProjectAsset[]): { label: string; items: ProjectAsset[] }[] {
+  const map = new Map<string, ProjectAsset[]>();
+  for (const a of assets) {
+    const g = getGroup(a.createdAt);
+    if (!map.has(g)) map.set(g, []);
+    map.get(g)!.push(a);
+  }
+  return GROUP_ORDER.filter((g) => map.has(g)).map((g) => ({
+    label: g,
+    items: map.get(g)!,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Asset card
+// ---------------------------------------------------------------------------
+
 function AssetCard({ asset, projectId }: { asset: ProjectAsset; projectId: string }) {
   const router = useRouter();
-  const video = asset.mediaType === "Video";
-  const date = new Date(asset.createdAt).toLocaleDateString(undefined, {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
+  const isVideo = asset.mediaType === "Video";
+
+  const time = new Date(asset.createdAt).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
   });
 
   return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.97 }}
-      animate={{ opacity: 1, scale: 1 }}
+    <motion.article
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
       onClick={() => router.push(`/projects/${projectId}/assets/${asset.id}`)}
-      className="group relative rounded-xl overflow-hidden bg-card border border-border/50 hover:border-border transition-all cursor-pointer"
+      className={cn(
+        "group relative rounded-xl overflow-hidden cursor-pointer",
+        "bg-[oklch(0.12_0.02_264)] border border-white/[0.07]",
+        "hover:border-[#ec4899]/40 hover:shadow-[0_0_24px_rgba(236,72,153,0.08)]",
+        "transition-all duration-200"
+      )}
     >
-      <div className="aspect-video bg-muted/40 relative flex items-center justify-center overflow-hidden">
-        {video ? (
+      {/* Media */}
+      <div className="aspect-video relative overflow-hidden bg-black/40">
+        {isVideo ? (
           <video
             src={asset.mediaUrl}
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
             muted
             playsInline
+            preload="metadata"
             onMouseEnter={(e) => (e.currentTarget as HTMLVideoElement).play()}
             onMouseLeave={(e) => {
               const v = e.currentTarget as HTMLVideoElement;
@@ -40,28 +98,106 @@ function AssetCard({ asset, projectId }: { asset: ProjectAsset; projectId: strin
             }}
           />
         ) : (
+          // eslint-disable-next-line @next/next/no-img-element
           <img
             src={asset.mediaUrl}
             alt="Generated asset"
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
           />
         )}
 
-        {/* type badge */}
-        <div className="absolute top-2 left-2 flex items-center gap-1 px-2 py-0.5 rounded-full bg-black/60 text-white text-xs font-medium backdrop-blur-sm">
-          {video
-            ? <><Video className="w-3 h-3" /> Video</>
-            : <><ImageIcon className="w-3 h-3" /> Image</>
-          }
+        {/* Gradient scrim */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+
+        {/* Type badge */}
+        <div className={cn(
+          "absolute top-2 left-2 flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold backdrop-blur-sm",
+          isVideo
+            ? "bg-red-500/20 text-red-300 border border-red-500/30"
+            : "bg-[#ec4899]/15 text-[#ec4899] border border-[#ec4899]/30"
+        )}>
+          {isVideo ? <Video className="w-2.5 h-2.5" /> : <ImageIcon className="w-2.5 h-2.5" />}
+          {isVideo ? "Video" : "Image"}
+        </div>
+
+        {/* View arrow — appears on hover */}
+        <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+          <div className="w-7 h-7 rounded-full bg-white/15 backdrop-blur-sm flex items-center justify-center border border-white/20">
+            <ChevronRight className="w-3.5 h-3.5 text-white" />
+          </div>
         </div>
       </div>
 
+      {/* Footer */}
       <div className="px-3 py-2 flex items-center justify-between">
-        <span className="text-xs text-muted-foreground">{date}</span>
+        <span className="text-[10px] font-mono text-white/30">{time}</span>
+        {asset.mediaType === "Video" && (
+          <div className="flex items-center gap-1">
+            <div className="w-1.5 h-1.5 rounded-full bg-red-400/60 animate-[pulse_2s_ease-in-out_infinite]" />
+            <span className="text-[9px] text-white/25">Video</span>
+          </div>
+        )}
       </div>
-    </motion.div>
+    </motion.article>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Section divider
+// ---------------------------------------------------------------------------
+
+function SectionDivider({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="flex items-center gap-3 mb-4 mt-8 first:mt-0">
+      <span className="text-[11px] font-semibold uppercase tracking-widest text-white/30 shrink-0">
+        {label}
+      </span>
+      <div className="flex-1 h-px bg-white/[0.06]" />
+      <span className="text-[10px] font-mono text-white/20 shrink-0">{count}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton loader
+// ---------------------------------------------------------------------------
+
+function SkeletonGrid() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="aspect-video rounded-xl bg-white/[0.04] animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-32 gap-5 text-center">
+      <div className={cn(
+        "w-20 h-20 rounded-2xl flex items-center justify-center",
+        "bg-[#ec4899]/8 border border-[#ec4899]/20"
+      )}>
+        <Sparkles className="w-8 h-8 text-[#ec4899]/50" />
+      </div>
+      <div className="space-y-1.5">
+        <p className="text-base font-semibold text-white/70">No assets yet</p>
+        <p className="text-sm text-white/30 max-w-xs leading-relaxed">
+          Run a template to generate your first asset — it will appear here automatically.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 
 export default function AssetsPage() {
   const params = useParams();
@@ -70,69 +206,89 @@ export default function AssetsPage() {
   const { projects, isLoading: projectsLoading } = useProjects();
   const { assets, isLoading, error, nextCursor, loadMore } = useProjectAssets(projectId);
 
+  const groups = useMemo(() => groupAssets(assets), [assets]);
+  const totalCount = assets.length;
+
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-[oklch(0.09_0.02_264)]">
       <ProjectHeader projects={projects} isLoading={projectsLoading} />
 
-      <div className="container mx-auto px-6 py-8">
+      <div className="container mx-auto px-6 py-8 max-w-7xl">
+        {/* Page header */}
         <motion.div
-          initial={{ opacity: 0, y: 12 }}
+          initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
-          className="mb-8"
+          transition={{ duration: 0.3 }}
+          className="mb-10 flex items-end justify-between"
         >
-          <h1 className="text-2xl font-bold">Generated Assets</h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            All media generated by your templates in this project.
-          </p>
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Sparkles className="w-4 h-4 text-[#ec4899]/70" />
+              <span className="text-[11px] font-semibold uppercase tracking-widest text-white/30">
+                Generated Assets
+              </span>
+            </div>
+            <h1 className="text-3xl font-bold text-white/90 tracking-tight">
+              Media Library
+            </h1>
+            <p className="text-sm text-white/35 mt-1.5">
+              Every video and image your templates have generated.
+            </p>
+          </div>
+          {totalCount > 0 && (
+            <div className={cn(
+              "px-3 py-1.5 rounded-lg border border-white/[0.08] bg-white/[0.04]",
+              "text-[11px] font-mono text-white/30"
+            )}>
+              {totalCount} asset{totalCount !== 1 ? "s" : ""}
+            </div>
+          )}
         </motion.div>
 
-        {/* Loading skeleton */}
-        {isLoading && assets.length === 0 && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="aspect-video rounded-xl bg-muted/40 animate-pulse" />
-            ))}
-          </div>
-        )}
+        {/* Loading */}
+        {isLoading && assets.length === 0 && <SkeletonGrid />}
 
         {/* Error */}
         {error && (
-          <div className="text-center py-20 text-destructive">{error}</div>
+          <div className="text-center py-20 text-red-400/70 text-sm">{error}</div>
         )}
 
-        {/* Empty state */}
-        {!isLoading && !error && assets.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-24 text-center gap-4">
-            <div className="w-16 h-16 rounded-2xl bg-muted/40 flex items-center justify-center">
-              <PackageOpen className="w-8 h-8 text-muted-foreground" />
-            </div>
-            <div>
-              <p className="font-medium">No assets yet</p>
-              <p className="text-sm text-muted-foreground mt-1">
-                Run a template to generate your first asset.
-              </p>
-            </div>
-          </div>
-        )}
+        {/* Empty */}
+        {!isLoading && !error && assets.length === 0 && <EmptyState />}
 
-        {/* Grid */}
-        {assets.length > 0 && (
-          <>
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-              {assets.map((asset) => (
-                <AssetCard key={asset.id} asset={asset} projectId={projectId} />
-              ))}
-            </div>
+        {/* Grouped grid */}
+        {groups.length > 0 && (
+          <div className="space-y-2">
+            {groups.map(({ label, items }) => (
+              <section key={label}>
+                <SectionDivider label={label} count={items.length} />
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                  {items.map((asset) => (
+                    <AssetCard key={asset.id} asset={asset} projectId={projectId} />
+                  ))}
+                </div>
+              </section>
+            ))}
 
+            {/* Load more */}
             {nextCursor && (
-              <div className="mt-8 flex justify-center">
-                <Button variant="outline" onClick={loadMore} disabled={isLoading}>
-                  {isLoading ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
-                  Load more
+              <div className="mt-10 flex justify-center">
+                <Button
+                  variant="outline"
+                  onClick={loadMore}
+                  disabled={isLoading}
+                  className={cn(
+                    "border-white/[0.12] bg-white/[0.04] text-white/50",
+                    "hover:bg-white/[0.08] hover:text-white/70 hover:border-white/20",
+                    "transition-all duration-150"
+                  )}
+                >
+                  {isLoading && <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />}
+                  Load older assets
                 </Button>
               </div>
             )}
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
@@ -210,7 +210,7 @@ export default function AssetsPage() {
   const totalCount = assets.length;
 
   return (
-    <div className="min-h-screen bg-[oklch(0.09_0.02_264)]">
+    <div className="min-h-screen bg-background">
       <ProjectHeader projects={projects} isLoading={projectsLoading} />
 
       <div className="container mx-auto px-6 py-8 max-w-7xl">

--- a/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
@@ -119,6 +119,7 @@ export default function TemplateCanvasPage() {
     addNode, deleteNode, deleteSelectedElements,
     updateNodeConfig, updateNodeData,
     appendNodeOutputHistory,
+    propagateOutputsDownstream,
     setNodes, setEdges,
     execution, submitWorkflow,
     setNodeStatus,
@@ -145,6 +146,9 @@ export default function TemplateCanvasPage() {
           updateNodeData(nodeId, { outputValues: outputs as Record<string, unknown> });
           // Accumulate image history — does nothing if outputs has no image_uuid
           appendNodeOutputHistory(nodeId, outputs as Record<string, unknown>);
+          // Push output values into all downstream connected nodes' config
+          // (this is what makes PreviewImageNode / PreviewTextNode display results)
+          propagateOutputsDownstream(nodeId, outputs as Record<string, unknown>);
         }
       },
       onPublicationStatusChanged: async () => {},
@@ -167,7 +171,7 @@ export default function TemplateCanvasPage() {
 
     const disposable = getReceiverRegister("IClientReceiver").register(connection, receiver);
     return () => disposable.dispose();
-  }, [connection, setNodeStatus, updateNodeData, appendNodeOutputHistory, toast]);
+  }, [connection, setNodeStatus, updateNodeData, appendNodeOutputHistory, propagateOutputsDownstream, toast]);
 
   // ── Load saved graph (waits for registry) ───────────────────────────────────
   const [isGraphReady, setIsGraphReady] = useState(false);

--- a/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, Play, PanelLeft, Image as ImageIcon } from "lucide-react";
+import { ArrowLeft, Play, PanelLeft, Image as ImageIcon, Sparkles } from "lucide-react";
 import {
   ReactFlow,
   Background,
@@ -38,6 +38,7 @@ import { NodeContextMenu } from "@/features/canvas/components/NodeContextMenu";
 import { NodeLibrarySidebar } from "@/features/canvas/components/NodeLibrarySidebar";
 import { MediaAssetsPanel } from "@/features/canvas/components/MediaAssetsPanel";
 import { TemplateMenu } from "@/features/canvas/components/TemplateMenu";
+import { GeneratedMediaPanel } from "@/features/canvas/components/GeneratedMediaPanel";
 import { useCanvasStore } from "@/features/canvas/hooks/useCanvasStore";
 import { useNodeRegistry } from "@/features/canvas/hooks/useNodeRegistry";
 import { getNodesByCategory, getNodeDef } from "@/features/canvas/registry";
@@ -66,7 +67,7 @@ const SEED_EDGES: CanvasEdge[] = [];
 // Page
 // ---------------------------------------------------------------------------
 
-type SidebarTab = "nodes" | "media";
+type SidebarTab = "nodes" | "media" | "generated";
 
 export default function TemplateCanvasPage() {
   const params    = useParams();
@@ -476,6 +477,17 @@ export default function TemplateCanvasPage() {
           >
             <ImageIcon className="w-4 h-4" />
           </Button>
+          <Button
+            variant="ghost" size="sm"
+            onClick={() => {
+              setSidebarTab("generated");
+              setSidebarOpen((v) => sidebarTab === "generated" ? !v : true);
+            }}
+            className={cn("text-muted-foreground hover:text-foreground w-8 h-8 p-0", sidebarOpen && sidebarTab === "generated" && "bg-white/[0.06] text-[#ec4899]")}
+            title="Generated media"
+          >
+            <Sparkles className="w-4 h-4" />
+          </Button>
         </div>
 
         <div className="h-4 w-px bg-border" />
@@ -547,7 +559,9 @@ export default function TemplateCanvasPage() {
       <div className="flex-1 flex overflow-hidden" style={{ minHeight: 0 }}>
         {sidebarTab === "nodes"
           ? <NodeLibrarySidebar isOpen={sidebarOpen} nodesByCategory={nodeLibrary} />
-          : <MediaAssetsPanel   isOpen={sidebarOpen} projectId={projectId} />
+          : sidebarTab === "media"
+            ? <MediaAssetsPanel   isOpen={sidebarOpen} projectId={projectId} />
+            : <GeneratedMediaPanel isOpen={sidebarOpen} nodes={nodes} />
         }
 
         <div className="flex-1" style={{ minHeight: 0 }}>

--- a/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/templates/[templateId]/page.tsx
@@ -118,6 +118,7 @@ export default function TemplateCanvasPage() {
     onNodesChange, onEdgesChange, onConnect,
     addNode, deleteNode, deleteSelectedElements,
     updateNodeConfig, updateNodeData,
+    appendNodeOutputHistory,
     setNodes, setEdges,
     execution, submitWorkflow,
     setNodeStatus,
@@ -142,6 +143,8 @@ export default function TemplateCanvasPage() {
 
         if (outputs && mapped === "success") {
           updateNodeData(nodeId, { outputValues: outputs as Record<string, unknown> });
+          // Accumulate image history — does nothing if outputs has no image_uuid
+          appendNodeOutputHistory(nodeId, outputs as Record<string, unknown>);
         }
       },
       onPublicationStatusChanged: async () => {},
@@ -164,7 +167,7 @@ export default function TemplateCanvasPage() {
 
     const disposable = getReceiverRegister("IClientReceiver").register(connection, receiver);
     return () => disposable.dispose();
-  }, [connection, setNodeStatus, updateNodeData, toast]);
+  }, [connection, setNodeStatus, updateNodeData, appendNodeOutputHistory, toast]);
 
   // ── Load saved graph (waits for registry) ───────────────────────────────────
   const [isGraphReady, setIsGraphReady] = useState(false);

--- a/frontend/src/features/canvas/components/AmplifyNode.tsx
+++ b/frontend/src/features/canvas/components/AmplifyNode.tsx
@@ -1,19 +1,5 @@
 "use client";
 
-// =============================================================================
-// AmplifyNode — The premium schema-driven node component (Weavy / ComfyUI style).
-//
-// Features:
-//   • Glassmorphic card: backdrop-blur + semi-transparent dark surface
-//   • Category-coloured 3 px top accent stripe
-//   • Header: category icon, display_name, live status badge, delete button
-//   • Port section: left input handles (non-widget) + right output handles
-//   • Widget section: inline controls for STRING / INT / FLOAT / BOOLEAN / COMBO
-//   • Advanced section: collapsible for advanced-flagged inputs
-//   • Status footer: idle / queued / processing (shimmer) / success / error
-//   • framer-motion entry animation
-// =============================================================================
-
 import React, { useState, useCallback, useEffect } from "react";
 import { type NodeProps, useUpdateNodeInternals } from "@xyflow/react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -29,12 +15,13 @@ import {
   CheckCircle2,
   AlertCircle,
   Clock,
+  Images,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { mediaUrl } from "@/lib/media";
-import type { CanvasNode, CanvasNodeData, NodeCategory, NodeExecutionStatus, PortDef } from "../types";
+import type { CanvasNode, CanvasNodeData, NodeCategory, NodeExecutionStatus, PortDef, ImageBatch } from "../types";
 import { NodePort } from "./NodePort";
 import { NodeWidget } from "./NodeWidget";
+import { NodeImageGallery } from "./NodeImageGallery";
 
 // ---------------------------------------------------------------------------
 // Category accent colours (inline styles — dynamic at runtime)
@@ -107,7 +94,6 @@ export function AmplifyNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   // Re-measure handle positions whenever the port list grows or shrinks
-  // (COMFY_AUTOGROW_V3 slots are added/removed dynamically)
   useEffect(() => {
     updateNodeInternals(id);
   }, [data.ports.length, id, updateNodeInternals]);
@@ -115,6 +101,10 @@ export function AmplifyNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const accentColor = CATEGORY_COLORS[data.categoryTag] ?? "#64748b";
   const CategoryIcon = CATEGORY_ICONS[data.categoryTag];
   const statusCfg = STATUS_CONFIG[data.status ?? "idle"];
+
+  // Derive output image history from node data
+  const outputHistory = (data.outputHistory as ImageBatch[] | undefined) ?? [];
+  const totalImages = outputHistory.reduce((sum, b) => sum + b.imageUuids.length, 0);
 
   // Callbacks injected by the canvas page into node.data
   const onUpdateConfig = data.onUpdateConfig as
@@ -197,6 +187,20 @@ export function AmplifyNode({ id, data, selected }: NodeProps<CanvasNode>) {
             {data.schemaName}
           </p>
         </div>
+
+        {/* Image counter badge — shown when there are stored images */}
+        {outputHistory.length > 0 && (
+          <div
+            className={cn(
+              "flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[9px] font-medium shrink-0",
+              "bg-[#ec4899]/15 text-[#ec4899]/80"
+            )}
+            title={`${totalImages} image${totalImages !== 1 ? "s" : ""} stored`}
+          >
+            <Images className="w-2.5 h-2.5" />
+            <span>{totalImages}</span>
+          </div>
+        )}
 
         {/* Status badge */}
         <div
@@ -327,10 +331,13 @@ export function AmplifyNode({ id, data, selected }: NodeProps<CanvasNode>) {
       )}
 
       {/* ----------------------------------------------------------------- */}
-      {/* Output preview — shown on success when the node produced media  */}
+      {/* Output image gallery — shown when the node has image history      */}
       {/* ----------------------------------------------------------------- */}
-      {data.status === "success" && data.outputValues && (
-        <NodeOutputPreview outputs={data.outputValues as Record<string, unknown[]>} />
+      {outputHistory.length > 0 && (
+        <NodeImageGallery
+          batches={outputHistory}
+          nodeName={data.displayName}
+        />
       )}
 
       {/* ----------------------------------------------------------------- */}
@@ -350,41 +357,6 @@ export function AmplifyNode({ id, data, selected }: NodeProps<CanvasNode>) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// NodeOutputPreview — renders image/video result inside the node after success
-// ---------------------------------------------------------------------------
-
-interface NodeOutputPreviewProps {
-  outputs: Record<string, unknown[]>;
-}
-
-function NodeOutputPreview({ outputs }: NodeOutputPreviewProps) {
-  const videoGuid = (outputs.video_uuid?.[0] as string | undefined);
-  const imageGuid = (outputs.image_uuid?.[0] as string | undefined);
-
-  if (!videoGuid && !imageGuid) return null;
-
-  return (
-    <div className="mx-3 mb-2 mt-1 rounded-lg overflow-hidden border border-white/[0.06]">
-      {videoGuid && (
-        // eslint-disable-next-line jsx-a11y/media-has-caption
-        <video
-          src={mediaUrl(videoGuid)}
-          controls
-          className="nodrag nopan nowheel w-full max-h-48 bg-black object-contain"
-        />
-      )}
-      {imageGuid && !videoGuid && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={mediaUrl(imageGuid)}
-          alt="Output"
-          className="nodrag nopan nowheel w-full max-h-48 object-contain bg-black"
-        />
-      )}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Port classification helpers

--- a/frontend/src/features/canvas/components/FullscreenGallery.tsx
+++ b/frontend/src/features/canvas/components/FullscreenGallery.tsx
@@ -9,8 +9,8 @@ import React, {
   useEffect,
   useRef,
   useState,
-  createPortal,
 } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   X,

--- a/frontend/src/features/canvas/components/FullscreenGallery.tsx
+++ b/frontend/src/features/canvas/components/FullscreenGallery.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+// =============================================================================
+// FullscreenGallery — Portal overlay for browsing all output images.
+// =============================================================================
+
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  createPortal,
+} from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Loader2,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mediaUrl } from "@/lib/media";
+import type { ImageBatch } from "../types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FullscreenGalleryProps {
+  /** Node display name shown in the top bar */
+  nodeName: string;
+  /** All batches for this node */
+  batches: ImageBatch[];
+  /** Flat list of all image UUIDs (for linear navigation) */
+  allImageUuids: string[];
+  /** The initially-focused image uuid */
+  initialUuid?: string;
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Image thumbnail with load state
+// ---------------------------------------------------------------------------
+
+function Thumbnail({
+  uuid,
+  isSelected,
+  onClick,
+}: {
+  uuid: string;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const url = mediaUrl(uuid);
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "nodrag nopan relative w-full aspect-square rounded-md overflow-hidden shrink-0",
+        "border-2 transition-all duration-150",
+        isSelected
+          ? "border-[#ec4899] shadow-[0_0_0_2px_#ec489955]"
+          : "border-transparent hover:border-white/20"
+      )}
+    >
+      {status === "loading" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white/[0.04]">
+          <Loader2 className="w-3 h-3 text-white/20 animate-spin" />
+        </div>
+      )}
+      {status === "error" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-red-900/20">
+          <AlertCircle className="w-3 h-3 text-red-400/60" />
+        </div>
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt=""
+        className={cn(
+          "w-full h-full object-cover transition-opacity duration-200",
+          status === "loaded" ? "opacity-100" : "opacity-0 absolute"
+        )}
+        onLoad={() => setStatus("loaded")}
+        onError={() => setStatus("error")}
+      />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Large preview
+// ---------------------------------------------------------------------------
+
+function LargePreview({ uuid }: { uuid: string }) {
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const url = mediaUrl(uuid);
+
+  // Reset to loading when the uuid changes
+  useEffect(() => {
+    setStatus("loading");
+  }, [uuid]);
+
+  const handleDownload = useCallback(() => {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${uuid}.jpg`;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }, [url, uuid]);
+
+  return (
+    <div className="relative flex-1 flex items-center justify-center overflow-hidden bg-black/60">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={uuid}
+          initial={{ opacity: 0, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 1.02 }}
+          transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+          className="flex items-center justify-center w-full h-full p-6"
+        >
+          {status === "loading" && (
+            <Loader2 className="absolute w-8 h-8 text-white/20 animate-spin" />
+          )}
+          {status === "error" && (
+            <div className="flex flex-col items-center gap-2">
+              <AlertCircle className="w-8 h-8 text-red-400/60" />
+              <p className="text-sm text-red-400/60">Failed to load image</p>
+            </div>
+          )}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={url}
+            alt="preview"
+            className={cn(
+              "max-w-full max-h-full object-contain rounded-lg",
+              "shadow-[0_24px_80px_rgba(0,0,0,0.6)]",
+              "transition-opacity duration-300",
+              status === "loaded" ? "opacity-100" : "opacity-0"
+            )}
+            onLoad={() => setStatus("loaded")}
+            onError={() => setStatus("error")}
+          />
+        </motion.div>
+      </AnimatePresence>
+
+      {/* Download button — bottom-right of preview */}
+      {status === "loaded" && (
+        <button
+          onClick={handleDownload}
+          className={cn(
+            "absolute bottom-4 right-4",
+            "w-8 h-8 rounded-full flex items-center justify-center",
+            "bg-black/60 border border-white/10",
+            "text-white/50 hover:text-white hover:bg-black/80",
+            "transition-all duration-150"
+          )}
+          title="Download image"
+        >
+          <Download className="w-3.5 h-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function FullscreenGallery({
+  nodeName,
+  allImageUuids,
+  initialUuid,
+  onClose,
+}: FullscreenGalleryProps) {
+  const initialIdx = initialUuid
+    ? Math.max(0, allImageUuids.indexOf(initialUuid))
+    : 0;
+
+  const [currentIdx, setCurrentIdx] = useState(initialIdx);
+  const thumbnailRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const total = allImageUuids.length;
+  const currentUuid = allImageUuids[currentIdx] ?? "";
+
+  const goTo = useCallback(
+    (idx: number) => {
+      const clamped = Math.max(0, Math.min(total - 1, idx));
+      setCurrentIdx(clamped);
+      // Scroll thumbnail into view
+      thumbnailRefs.current[clamped]?.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    },
+    [total]
+  );
+
+  const goPrev = useCallback(() => goTo(currentIdx - 1), [currentIdx, goTo]);
+  const goNext = useCallback(() => goTo(currentIdx + 1), [currentIdx, goTo]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      if (e.key === "ArrowLeft") goPrev();
+      if (e.key === "ArrowRight") goNext();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose, goPrev, goNext]);
+
+  // Trap scroll outside
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  return createPortal(
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.18 }}
+      className={cn(
+        "fixed inset-0 z-[9999] flex flex-col",
+        "bg-[oklch(0.08_0.03_264/0.97)] backdrop-blur-xl"
+      )}
+      // Click backdrop closes
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      {/* ------------------------------------------------------------------ */}
+      {/* Top bar */}
+      {/* ------------------------------------------------------------------ */}
+      <div
+        className={cn(
+          "flex items-center gap-3 px-4 h-12 shrink-0",
+          "border-b border-white/[0.06]",
+          "bg-white/[0.02]"
+        )}
+      >
+        {/* Close */}
+        <button
+          onClick={onClose}
+          className={cn(
+            "w-7 h-7 rounded-md flex items-center justify-center shrink-0",
+            "text-white/40 hover:text-white hover:bg-white/[0.08]",
+            "transition-all duration-150"
+          )}
+          title="Close gallery (Esc)"
+        >
+          <X className="w-4 h-4" />
+        </button>
+
+        {/* Node name */}
+        <span className="text-sm font-semibold text-white/90 truncate flex-1">
+          {nodeName}
+        </span>
+
+        {/* Counter */}
+        <span className="text-xs font-mono text-white/40 shrink-0">
+          {currentIdx + 1} / {total}
+        </span>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Body: large preview (left) + thumbnail strip (right)               */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="flex-1 flex overflow-hidden min-h-0">
+        {/* Navigation arrow — prev */}
+        <button
+          onClick={goPrev}
+          disabled={currentIdx === 0}
+          className={cn(
+            "absolute left-3 top-1/2 -translate-y-1/2 z-10",
+            "w-9 h-9 rounded-full flex items-center justify-center",
+            "bg-black/60 border border-white/10",
+            "text-white/60 hover:text-white hover:bg-black/80",
+            "transition-all duration-150",
+            "disabled:opacity-20 disabled:cursor-not-allowed"
+          )}
+          title="Previous (←)"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+
+        {/* Large preview */}
+        <LargePreview uuid={currentUuid} />
+
+        {/* Navigation arrow — next */}
+        <button
+          onClick={goNext}
+          disabled={currentIdx === total - 1}
+          className={cn(
+            "absolute right-[240px] top-1/2 -translate-y-1/2 z-10",
+            "w-9 h-9 rounded-full flex items-center justify-center",
+            "bg-black/60 border border-white/10",
+            "text-white/60 hover:text-white hover:bg-black/80",
+            "transition-all duration-150",
+            "disabled:opacity-20 disabled:cursor-not-allowed"
+          )}
+          title="Next (→)"
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
+
+        {/* Thumbnail strip */}
+        <div
+          className={cn(
+            "w-[220px] shrink-0 flex flex-col overflow-y-auto overflow-x-hidden",
+            "border-l border-white/[0.06] bg-white/[0.02]",
+            "p-3 gap-2"
+          )}
+        >
+          {allImageUuids.map((uuid, idx) => (
+            <div
+              key={uuid}
+              ref={(el) => { thumbnailRefs.current[idx] = el; }}
+            >
+              <Thumbnail
+                uuid={uuid}
+                isSelected={idx === currentIdx}
+                onClick={() => goTo(idx)}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </motion.div>,
+    document.body
+  );
+}

--- a/frontend/src/features/canvas/components/FullscreenGallery.tsx
+++ b/frontend/src/features/canvas/components/FullscreenGallery.tsx
@@ -25,6 +25,18 @@ import { mediaUrl } from "@/lib/media";
 import type { ImageBatch } from "../types";
 
 // ---------------------------------------------------------------------------
+// URL helper — handles both full URLs and bare GUIDs
+// ---------------------------------------------------------------------------
+
+function resolveImgUrl(uuidOrUrl: string): string {
+  if (!uuidOrUrl) return "";
+  if (uuidOrUrl.startsWith("http://") || uuidOrUrl.startsWith("https://") || uuidOrUrl.startsWith("/")) {
+    return uuidOrUrl;
+  }
+  return mediaUrl(uuidOrUrl);
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -54,8 +66,7 @@ function Thumbnail({
   onClick: () => void;
 }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const url = mediaUrl(uuid);
-
+  const url = resolveImgUrl(uuid);
   return (
     <button
       onClick={onClick}
@@ -98,7 +109,7 @@ function Thumbnail({
 
 function LargePreview({ uuid }: { uuid: string }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const url = mediaUrl(uuid);
+  const url = resolveImgUrl(uuid);
 
   // Reset to loading when the uuid changes
   useEffect(() => {

--- a/frontend/src/features/canvas/components/GeneratedMediaPanel.tsx
+++ b/frontend/src/features/canvas/components/GeneratedMediaPanel.tsx
@@ -23,6 +23,18 @@ import type { CanvasNode, ImageBatch } from "../types";
 import { FullscreenGallery } from "./FullscreenGallery";
 
 // ---------------------------------------------------------------------------
+// URL helper — handles both full URLs (ambassador images) and bare GUIDs
+// ---------------------------------------------------------------------------
+
+function resolveImgUrl(uuidOrUrl: string): string {
+  if (!uuidOrUrl) return "";
+  if (uuidOrUrl.startsWith("http://") || uuidOrUrl.startsWith("https://") || uuidOrUrl.startsWith("/")) {
+    return uuidOrUrl;
+  }
+  return mediaUrl(uuidOrUrl);
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -57,7 +69,7 @@ function Thumb({
   onClick: () => void;
 }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const url = mediaUrl(uuid);
+  const url = resolveImgUrl(uuid);
 
   return (
     <button

--- a/frontend/src/features/canvas/components/GeneratedMediaPanel.tsx
+++ b/frontend/src/features/canvas/components/GeneratedMediaPanel.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+// =============================================================================
+// GeneratedMediaPanel — Sidebar panel for browsing all intermediate outputs
+// =============================================================================
+
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Sparkles,
+  Loader2,
+  AlertCircle,
+  Maximize2,
+  ImageOff,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mediaUrl } from "@/lib/media";
+import type { CanvasNode, ImageBatch } from "../types";
+import { FullscreenGallery } from "./FullscreenGallery";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RunEntry {
+  /** Node this batch came from */
+  nodeId: string;
+  nodeName: string;
+  /** The batch itself */
+  batch: ImageBatch;
+  /** Monotonically increasing across all nodes — used for "global run" ordering */
+  globalOrder: number;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface GeneratedMediaPanelProps {
+  isOpen: boolean;
+  nodes: CanvasNode[];
+}
+
+// ---------------------------------------------------------------------------
+// Thumbnail with load state
+// ---------------------------------------------------------------------------
+
+function Thumb({
+  uuid,
+  onClick,
+}: {
+  uuid: string;
+  onClick: () => void;
+}) {
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const url = mediaUrl(uuid);
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "group relative aspect-square rounded-md overflow-hidden",
+        "border border-white/[0.06] bg-white/[0.03]",
+        "hover:border-[#ec4899]/50 hover:scale-[1.03]",
+        "transition-all duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#ec4899]"
+      )}
+    >
+      {status === "loading" && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="w-3 h-3 text-white/15 animate-spin" />
+        </div>
+      )}
+      {status === "error" && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <AlertCircle className="w-3 h-3 text-red-400/30" />
+        </div>
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt=""
+        className={cn(
+          "w-full h-full object-cover transition-opacity duration-200",
+          status === "loaded" ? "opacity-100" : "opacity-0 absolute"
+        )}
+        onLoad={() => setStatus("loaded")}
+        onError={() => setStatus("error")}
+      />
+      {/* Hover overlay */}
+      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors duration-150 flex items-center justify-center">
+        <Maximize2 className="w-3.5 h-3.5 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run batch card
+// ---------------------------------------------------------------------------
+
+function BatchCard({
+  entry,
+  onOpenGallery,
+}: {
+  entry: RunEntry;
+  onOpenGallery: (allUuids: string[], startUuid: string) => void;
+}) {
+  const { batch, nodeName } = entry;
+  const imageCount = batch.imageUuids.length;
+
+  return (
+    <div className="group">
+      {/* Batch header row */}
+      <div className="flex items-center gap-2 mb-1.5">
+        {/* Node name badge */}
+        <span
+          className={cn(
+            "text-[9px] font-medium px-1.5 py-0.5 rounded-full shrink-0",
+            "bg-[#ec4899]/12 text-[#ec4899]/70"
+          )}
+        >
+          {nodeName}
+        </span>
+        <span className="text-[9px] text-white/20 font-mono shrink-0">
+          Run {batch.runIndex + 1}
+        </span>
+        <div className="flex-1 h-px bg-white/[0.05]" />
+        <span className="text-[9px] text-white/20 shrink-0">
+          {imageCount} img{imageCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Thumbnail grid */}
+      <div className="grid grid-cols-2 gap-1">
+        {batch.imageUuids.map((uuid) => (
+          <Thumb
+            key={uuid}
+            uuid={uuid}
+            onClick={() => onOpenGallery(batch.imageUuids, uuid)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GeneratedMediaPanel({ isOpen, nodes }: GeneratedMediaPanelProps) {
+  const [galleryOpen, setGalleryOpen]   = useState(false);
+  const [galleryUuids, setGalleryUuids] = useState<string[]>([]);
+  const [galleryStart, setGalleryStart] = useState<string | undefined>();
+  const [galleryName, setGalleryName]   = useState("Generated images");
+
+  // Collect all runs from all nodes — flattened and sorted by runIndex per node,
+  // then interleaved in node order so newest is at the top.
+  const runs = useMemo<RunEntry[]>(() => {
+    const entries: RunEntry[] = [];
+    let globalOrder = 0;
+
+    for (const node of nodes) {
+      const history = (node.data.outputHistory as ImageBatch[] | undefined) ?? [];
+      for (const batch of history) {
+        entries.push({
+          nodeId:      node.id,
+          nodeName:    node.data.displayName as string,
+          batch,
+          globalOrder: globalOrder++,
+        });
+      }
+    }
+
+    // Sort newest first: highest globalOrder = last added = top
+    return entries.reverse();
+  }, [nodes]);
+
+  const totalImages = useMemo(
+    () => runs.reduce((sum, e) => sum + e.batch.imageUuids.length, 0),
+    [runs]
+  );
+
+  const openGallery = useCallback(
+    (uuids: string[], startUuid: string, nodeName?: string) => {
+      setGalleryUuids(uuids);
+      setGalleryStart(startUuid);
+      setGalleryName(nodeName ?? "Generated images");
+      setGalleryOpen(true);
+    },
+    []
+  );
+
+  // All images flat list for the "view all" fullscreen mode
+  const allUuids = useMemo(
+    () => runs.flatMap((e) => e.batch.imageUuids),
+    [runs]
+  );
+
+  return (
+    <>
+      {/* ------------------------------------------------------------------ */}
+      {/* Side panel */}
+      {/* ------------------------------------------------------------------ */}
+      <AnimatePresence>
+        {isOpen && (
+          <motion.aside
+            key="generated-panel"
+            initial={{ width: 0, opacity: 0 }}
+            animate={{ width: 240, opacity: 1 }}
+            exit={{ width: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            className={cn(
+              "h-full shrink-0 flex flex-col overflow-hidden",
+              "border-r border-white/[0.06]",
+              "bg-[oklch(0.10_0.02_264/0.95)] backdrop-blur-xl"
+            )}
+          >
+            {/* Panel header */}
+            <div className="flex items-center gap-2 px-3 py-3 border-b border-white/[0.05] shrink-0">
+              <Sparkles className="w-3.5 h-3.5 text-[#ec4899]/70 shrink-0" />
+              <span className="text-[11px] font-semibold text-white/70 flex-1">
+                Generated Media
+              </span>
+              {totalImages > 0 && (
+                <span className="text-[9px] font-mono text-white/25">
+                  {totalImages}
+                </span>
+              )}
+            </div>
+
+            {/* Content */}
+            {runs.length === 0 ? (
+              <EmptyState />
+            ) : (
+              <>
+                {/* "View all" button */}
+                {totalImages > 1 && (
+                  <div className="px-3 pt-2.5 shrink-0">
+                    <button
+                      onClick={() => openGallery(allUuids, allUuids[0], "All generated media")}
+                      className={cn(
+                        "w-full text-[9px] font-medium py-1.5 rounded-md",
+                        "border border-white/[0.07] bg-white/[0.03]",
+                        "text-white/40 hover:text-[#ec4899]/80 hover:border-[#ec4899]/30 hover:bg-[#ec4899]/5",
+                        "transition-all duration-150"
+                      )}
+                    >
+                      View all {totalImages} images ↗
+                    </button>
+                  </div>
+                )}
+
+                {/* Scrollable run list */}
+                <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-2.5 space-y-4 min-h-0">
+                  {runs.map((entry) => (
+                    <BatchCard
+                      key={`${entry.nodeId}-${entry.batch.runIndex}`}
+                      entry={entry}
+                      onOpenGallery={(uuids, uuid) =>
+                        openGallery(uuids, uuid, entry.nodeName)
+                      }
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </motion.aside>
+        )}
+      </AnimatePresence>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Fullscreen gallery portal */}
+      {/* ------------------------------------------------------------------ */}
+      <AnimatePresence>
+        {galleryOpen && (
+          <FullscreenGallery
+            nodeName={galleryName}
+            batches={[{ runIndex: 0, imageUuids: galleryUuids }]}
+            allImageUuids={galleryUuids}
+            initialUuid={galleryStart}
+            onClose={() => setGalleryOpen(false)}
+          />
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-4 gap-3">
+      <div
+        className={cn(
+          "w-10 h-10 rounded-full flex items-center justify-center",
+          "bg-white/[0.04] border border-white/[0.06]"
+        )}
+      >
+        <ImageOff className="w-4 h-4 text-white/15" />
+      </div>
+      <div className="text-center">
+        <p className="text-[11px] font-medium text-white/30">No outputs yet</p>
+        <p className="text-[9px] text-white/15 leading-relaxed mt-0.5">
+          Run a node that produces images<br />— they appear here automatically.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/canvas/components/ImportMediaNode.tsx
+++ b/frontend/src/features/canvas/components/ImportMediaNode.tsx
@@ -3,23 +3,22 @@
 // =============================================================================
 // ImportMediaNode — Input node for attaching media from the library.
 //
-// Shows a preview of the currently attached image/video and allows users to
-// select a new media asset via drag-drop or upload from the sidebar.
-// Outputs both image_uuid and video_uuid ports (only the selected type produces a value).
+// Shows a gallery of all previously imported images (using NodeImageGallery)
+// or a single video preview. Each time a user attaches a new image, it is
+// appended to outputHistory so the full import history is browseable.
 // =============================================================================
 
-import React, { useState } from "react";
+import React from "react";
 import { type NodeProps } from "@xyflow/react";
 import { motion } from "framer-motion";
 import {
   ImageIcon,
   VideoIcon,
-  Loader2,
-  AlertCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { CanvasNode } from "../types";
+import type { CanvasNode, ImageBatch } from "../types";
 import { NodePort } from "./NodePort";
+import { NodeImageGallery } from "./NodeImageGallery";
 
 // ---------------------------------------------------------------------------
 // Media URL helper
@@ -37,13 +36,22 @@ function getMediaUrl(uuidOrUrl: string): string {
 // ---------------------------------------------------------------------------
 
 export function ImportMediaNode({ id, data, selected }: NodeProps<CanvasNode>) {
-  // Determine which media type is attached (image or video)
   const imageUuid = (data.config?.image_uuid as string | undefined) || "";
   const videoUuid = (data.config?.video_uuid as string | undefined) || "";
   const hasImage = imageUuid && imageUuid.trim() !== "";
   const hasVideo = videoUuid && videoUuid.trim() !== "";
 
-  // Determine the variant to display
+  // Image gallery history — persisted in outputHistory.
+  // If outputHistory exists use it; otherwise synthesise a single batch from
+  // the current config value so existing saved nodes still show something.
+  const storedHistory = (data.outputHistory as ImageBatch[] | undefined) ?? [];
+  const outputHistory: ImageBatch[] =
+    storedHistory.length > 0
+      ? storedHistory
+      : hasImage
+        ? [{ runIndex: 0, imageUuids: [imageUuid] }]
+        : [];
+
   const variant = hasImage ? "image" : hasVideo ? "video" : null;
 
   return (
@@ -60,7 +68,7 @@ export function ImportMediaNode({ id, data, selected }: NodeProps<CanvasNode>) {
       )}
       style={
         selected
-          ? { boxShadow: `0 0 0 2px #3b82f688, 0 8px 32px rgba(0,0,0,0.5)` }
+          ? { boxShadow: "0 0 0 2px #3b82f688, 0 8px 32px rgba(0,0,0,0.5)" }
           : undefined
       }
     >
@@ -99,15 +107,17 @@ export function ImportMediaNode({ id, data, selected }: NodeProps<CanvasNode>) {
       <div className="mx-3 h-px bg-white/[0.05] mb-1" />
 
       {/* Preview area */}
-      <div className="mx-3 mb-3">
-        {!variant ? (
-          <EmptyMediaPreview />
-        ) : variant === "image" ? (
-          <ImagePreview uuid={imageUuid} />
-        ) : (
+      {variant === "image" ? (
+        <NodeImageGallery batches={outputHistory} nodeName={data.displayName} />
+      ) : variant === "video" ? (
+        <div className="mx-3 mb-3">
           <VideoPreview uuid={videoUuid} />
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="mx-3 mb-3">
+          <EmptyMediaPreview />
+        </div>
+      )}
 
       {/* Output handles row */}
       <div className="py-1">
@@ -144,41 +154,12 @@ function EmptyMediaPreview() {
   );
 }
 
-function ImagePreview({ uuid }: { uuid: string }) {
-  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
-
-  return (
-    <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video flex items-center justify-center mb-2">
-      {status === "loading" && (
-        <Loader2 className="w-5 h-5 text-muted-foreground/30 animate-spin" />
-      )}
-      {status === "error" && (
-        <div className="flex flex-col items-center gap-1">
-          <AlertCircle className="w-5 h-5 text-red-400/60" />
-          <p className="text-[10px] text-red-400/60">Failed to load</p>
-        </div>
-      )}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={url}
-        alt="imported media"
-        className={cn(
-          "w-full h-full object-contain transition-opacity duration-300",
-          status === "loaded" ? "opacity-100" : "opacity-0 absolute"
-        )}
-        onLoad={() => setStatus("loaded")}
-        onError={() => setStatus("error")}
-      />
-    </div>
-  );
-}
-
 function VideoPreview({ uuid }: { uuid: string }) {
   const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
 
   return (
     <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video mb-2">
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         src={url}
         controls

--- a/frontend/src/features/canvas/components/NodeImageGallery.tsx
+++ b/frontend/src/features/canvas/components/NodeImageGallery.tsx
@@ -27,6 +27,19 @@ import type { ImageBatch, ImageViewMode } from "../types";
 import { FullscreenGallery } from "./FullscreenGallery";
 
 // ---------------------------------------------------------------------------
+// URL helper — handles both full URLs (ambassador images) and bare GUIDs
+// (generated images from media-ingest). Must match getMediaUrl in nodes.
+// ---------------------------------------------------------------------------
+
+function resolveImgUrl(uuidOrUrl: string): string {
+  if (!uuidOrUrl) return "";
+  if (uuidOrUrl.startsWith("http://") || uuidOrUrl.startsWith("https://") || uuidOrUrl.startsWith("/")) {
+    return uuidOrUrl;
+  }
+  return mediaUrl(uuidOrUrl);
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -51,7 +64,7 @@ function ImageCard({
   className?: string;
 }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  const url = mediaUrl(uuid);
+  const url = resolveImgUrl(uuid);
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events

--- a/frontend/src/features/canvas/components/NodeImageGallery.tsx
+++ b/frontend/src/features/canvas/components/NodeImageGallery.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+// =============================================================================
+// NodeImageGallery — Inline image gallery for AmplifyNode.
+// =============================================================================
+
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+} from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Maximize2,
+  Layers,
+  LayoutGrid,
+  Square,
+  Loader2,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mediaUrl } from "@/lib/media";
+import type { ImageBatch, ImageViewMode } from "../types";
+import { FullscreenGallery } from "./FullscreenGallery";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NodeImageGalleryProps {
+  /** All batches for this node, oldest first */
+  batches: ImageBatch[];
+  /** Node display name (forwarded to fullscreen gallery) */
+  nodeName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Single image card with load state
+// ---------------------------------------------------------------------------
+
+function ImageCard({
+  uuid,
+  onClick,
+  className,
+}: {
+  uuid: string;
+  onClick?: (uuid: string) => void;
+  className?: string;
+}) {
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const url = mediaUrl(uuid);
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={() => onClick?.(uuid)}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onClick?.(uuid); }}
+      className={cn(
+        "relative overflow-hidden rounded-md bg-black/30",
+        "border border-white/[0.06]",
+        onClick && "cursor-pointer hover:border-[#ec4899]/40 transition-colors duration-150",
+        className
+      )}
+    >
+      {status === "loading" && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="w-4 h-4 text-white/20 animate-spin" />
+        </div>
+      )}
+      {status === "error" && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+          <AlertCircle className="w-4 h-4 text-red-400/40" />
+          <span className="text-[9px] text-red-400/40">Error</span>
+        </div>
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt=""
+        className={cn(
+          "nodrag nopan nowheel w-full h-full object-cover transition-opacity duration-300",
+          status === "loaded" ? "opacity-100" : "opacity-0"
+        )}
+        onLoad={() => setStatus("loaded")}
+        onError={() => setStatus("error")}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// View mode toggle button group
+// ---------------------------------------------------------------------------
+
+const MODES: { mode: ImageViewMode; icon: React.ReactNode; title: string }[] = [
+  { mode: "single", icon: <Square className="w-3 h-3" />, title: "Single" },
+  { mode: "batch", icon: <Layers className="w-3 h-3" />, title: "Batch" },
+  { mode: "all", icon: <LayoutGrid className="w-3 h-3" />, title: "All" },
+];
+
+function ModeToggle({
+  current,
+  onChange,
+}: {
+  current: ImageViewMode;
+  onChange: (m: ImageViewMode) => void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 bg-white/[0.05] rounded-md p-0.5">
+      {MODES.map(({ mode, icon, title }) => (
+        <button
+          key={mode}
+          title={title}
+          onClick={() => onChange(mode)}
+          className={cn(
+            "nodrag px-1.5 py-0.5 rounded flex items-center gap-1",
+            "text-[9px] font-medium transition-all duration-150",
+            current === mode
+              ? "bg-[#ec4899]/20 text-[#ec4899]"
+              : "text-white/30 hover:text-white/60"
+          )}
+        >
+          {icon}
+          <span className="leading-none">{title}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function NodeImageGallery({ batches, nodeName }: NodeImageGalleryProps) {
+  const [viewMode, setViewMode] = useState<ImageViewMode>("single");
+  const [singleIndex, setSingleIndex] = useState(0);
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [galleryUuid, setGalleryUuid] = useState<string | undefined>();
+
+  // Flat list of ALL image UUIDs, oldest→newest
+  const allImages = useMemo(
+    () => batches.flatMap((b) => b.imageUuids),
+    [batches]
+  );
+
+  const totalImages = allImages.length;
+
+  // When new images arrive (new run completes), jump to the latest image
+  useEffect(() => {
+    if (totalImages > 0) {
+      setSingleIndex(totalImages - 1);
+    }
+  }, [totalImages]);
+
+  const goSinglePrev = useCallback(() =>
+    setSingleIndex((i) => Math.max(0, i - 1)), []);
+  const goSingleNext = useCallback(() =>
+    setSingleIndex((i) => Math.min(totalImages - 1, i + 1)), [totalImages]);
+
+  const openGallery = useCallback((uuid?: string) => {
+    setGalleryUuid(uuid);
+    setGalleryOpen(true);
+  }, []);
+
+  if (totalImages === 0) return null;
+
+  const currentUuid = allImages[singleIndex] ?? "";
+  // Latest batch (last in the array)
+  const latestBatch = batches[batches.length - 1];
+
+  return (
+    <>
+      {/* ------------------------------------------------------------------ */}
+      {/* Gallery panel */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="mx-2 mb-2 mt-1 rounded-lg overflow-hidden border border-white/[0.06] bg-black/20">
+        {/* Top bar: mode toggle + counter + fullscreen button */}
+        <div className="flex items-center justify-between gap-2 px-2 py-1.5 border-b border-white/[0.05]">
+          <ModeToggle current={viewMode} onChange={setViewMode} />
+
+          <div className="flex items-center gap-1.5">
+            {/* Image counter */}
+            <span className="text-[9px] font-mono text-white/30">
+              {viewMode === "single"
+                ? `${singleIndex + 1}/${totalImages}`
+                : `${totalImages} images`}
+            </span>
+
+            {/* Open fullscreen */}
+            <button
+              title="Open in gallery"
+              onClick={() => openGallery(currentUuid)}
+              className={cn(
+                "nodrag w-5 h-5 rounded flex items-center justify-center",
+                "text-white/25 hover:text-[#ec4899] hover:bg-[#ec4899]/10",
+                "transition-all duration-150"
+              )}
+            >
+              <Maximize2 className="w-3 h-3" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content area */}
+        <AnimatePresence mode="wait">
+          {viewMode === "single" ? (
+            <motion.div
+              key="single"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+            >
+              {/* Single image view with arrow navigation */}
+              <div className="relative group">
+                <ImageCard
+                  uuid={currentUuid}
+                  onClick={openGallery}
+                  className="aspect-[4/3] w-full"
+                />
+                {/* Left arrow */}
+                {singleIndex > 0 && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); goSinglePrev(); }}
+                    className={cn(
+                      "nodrag absolute left-1.5 top-1/2 -translate-y-1/2",
+                      "w-6 h-6 rounded-full flex items-center justify-center",
+                      "bg-black/70 border border-white/10",
+                      "text-white/60 hover:text-white",
+                      "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                    )}
+                  >
+                    <ChevronLeft className="w-3.5 h-3.5" />
+                  </button>
+                )}
+                {/* Right arrow */}
+                {singleIndex < totalImages - 1 && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); goSingleNext(); }}
+                    className={cn(
+                      "nodrag absolute right-1.5 top-1/2 -translate-y-1/2",
+                      "w-6 h-6 rounded-full flex items-center justify-center",
+                      "bg-black/70 border border-white/10",
+                      "text-white/60 hover:text-white",
+                      "opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+                    )}
+                  >
+                    <ChevronRight className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
+            </motion.div>
+          ) : viewMode === "batch" ? (
+            <motion.div
+              key="batch"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              className="p-2 flex flex-col gap-2"
+            >
+              {/* Show most recent batch first */}
+              {[...batches].reverse().map((batch) => (
+                <div key={batch.runIndex}>
+                  <p className="text-[8px] text-white/20 font-mono mb-1">
+                    Run {batch.runIndex + 1} · {batch.imageUuids.length} image{batch.imageUuids.length !== 1 ? "s" : ""}
+                  </p>
+                  <div className="grid grid-cols-2 gap-1">
+                    {batch.imageUuids.map((uuid) => (
+                      <ImageCard
+                        key={uuid}
+                        uuid={uuid}
+                        onClick={openGallery}
+                        className="aspect-square"
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </motion.div>
+          ) : (
+            <motion.div
+              key="all"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              className="p-2"
+            >
+              {/* Flat 2×N grid: most recent first */}
+              {batches.length > 1 && (
+                <p className="text-[8px] text-white/20 font-mono mb-1">
+                  {batches.length} runs · {totalImages} images total
+                </p>
+              )}
+              <div className="grid grid-cols-2 gap-1">
+                {[...allImages].reverse().map((uuid, revIdx) => (
+                  <ImageCard
+                    key={`${uuid}-${revIdx}`}
+                    uuid={uuid}
+                    onClick={openGallery}
+                    className="aspect-square"
+                  />
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Fullscreen gallery portal */}
+      {/* ------------------------------------------------------------------ */}
+      <AnimatePresence>
+        {galleryOpen && (
+          <FullscreenGallery
+            nodeName={nodeName}
+            batches={batches}
+            allImageUuids={allImages}
+            initialUuid={galleryUuid}
+            onClose={() => setGalleryOpen(false)}
+          />
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/frontend/src/features/canvas/components/PreviewNode.tsx
+++ b/frontend/src/features/canvas/components/PreviewNode.tsx
@@ -4,9 +4,9 @@
 // PreviewNode — Output-sink node for visualising text / image / video results.
 //
 // After a workflow completes, the canvas store propagates upstream outputValues
-// into downstream nodes' config.  PreviewNode reads config[portId] and renders:
+// into downstream nodes' config and outputHistory.  PreviewNode renders:
 //   • PreviewTextNode  → scrollable text area
-//   • PreviewImageNode → <img> fetched from media-ingest
+//   • PreviewImageNode → NodeImageGallery (multi-image with Single/Batch/All)
 //   • PreviewVideoNode → <video> fetched from media-ingest
 // =============================================================================
 
@@ -22,15 +22,15 @@ import {
   Maximize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { CanvasNode } from "../types";
+import type { CanvasNode, ImageBatch } from "../types";
 import { NodePort } from "./NodePort";
+import { NodeImageGallery } from "./NodeImageGallery";
 
 // ---------------------------------------------------------------------------
 // Media URL helper (mirrors mediaApi.getMediaUrl)
 // ---------------------------------------------------------------------------
 
 function getMediaUrl(uuidOrUrl: string): string {
-  // If it's already a full URL (mock placeholder or direct CDN link), use it as-is
   if (uuidOrUrl.startsWith("http://") || uuidOrUrl.startsWith("https://")) return uuidOrUrl;
   const base =
     process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://staging.alexeykiselev.tech";
@@ -70,7 +70,11 @@ export function PreviewNode({ id, data, selected }: NodeProps<CanvasNode>) {
   const accentColor = VARIANT_COLORS[variant];
   const Icon = VARIANT_ICONS[variant];
 
-  // Get the single input port value from config
+  // Image gallery — populated by propagateOutputsDownstream via outputHistory
+  const outputHistory = (data.outputHistory as ImageBatch[] | undefined) ?? [];
+  const hasImageHistory = variant === "image" && outputHistory.length > 0;
+
+  // Text / video — still read from config directly
   const inputPort = data.ports.find((p) => p.direction === "input");
   const rawValue = inputPort ? (data.config[inputPort.id] as string | undefined) : undefined;
   const hasValue = rawValue !== undefined && rawValue !== "";
@@ -131,17 +135,25 @@ export function PreviewNode({ id, data, selected }: NodeProps<CanvasNode>) {
       </div>
 
       {/* Preview area */}
-      <div className="mx-3 mb-3 mt-1">
-        {!hasValue ? (
-          <EmptyPreview variant={variant} accentColor={accentColor} />
-        ) : variant === "text" ? (
-          <TextPreview value={rawValue!} />
-        ) : variant === "image" ? (
-          <ImagePreview uuid={rawValue!} />
+      {variant === "image" ? (
+        hasImageHistory ? (
+          <NodeImageGallery batches={outputHistory} nodeName={data.displayName} />
         ) : (
-          <VideoPreview uuid={rawValue!} />
-        )}
-      </div>
+          <div className="mx-3 mb-3 mt-1">
+            <EmptyPreview variant={variant} accentColor={accentColor} />
+          </div>
+        )
+      ) : (
+        <div className="mx-3 mb-3 mt-1">
+          {!hasValue ? (
+            <EmptyPreview variant={variant} accentColor={accentColor} />
+          ) : variant === "text" ? (
+            <TextPreview value={rawValue!} />
+          ) : (
+            <VideoPreview uuid={rawValue!} />
+          )}
+        </div>
+      )}
     </motion.div>
   );
 }
@@ -200,42 +212,12 @@ function TextPreview({ value }: { value: string }) {
   );
 }
 
-function ImagePreview({ uuid }: { uuid: string }) {
-  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
-  // If uuid is already a full URL (mock or ambassador image), use it directly
-  const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
-
-  return (
-    <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video flex items-center justify-center">
-      {status === "loading" && (
-        <Loader2 className="w-5 h-5 text-muted-foreground/30 animate-spin" />
-      )}
-      {status === "error" && (
-        <div className="flex flex-col items-center gap-1">
-          <AlertCircle className="w-5 h-5 text-red-400/60" />
-          <p className="text-[10px] text-red-400/60">Failed to load</p>
-        </div>
-      )}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={url}
-        alt="output preview"
-        className={cn(
-          "w-full h-full object-contain transition-opacity duration-300",
-          status === "loaded" ? "opacity-100" : "opacity-0 absolute"
-        )}
-        onLoad={() => setStatus("loaded")}
-        onError={() => setStatus("error")}
-      />
-    </div>
-  );
-}
-
 function VideoPreview({ uuid }: { uuid: string }) {
   const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
 
   return (
     <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video">
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         src={url}
         controls

--- a/frontend/src/features/canvas/hooks/useCanvasStore.ts
+++ b/frontend/src/features/canvas/hooks/useCanvasStore.ts
@@ -325,7 +325,6 @@ export function useCanvasStore({
   const propagateOutputsDownstream = useCallback(
     (nodeId: string, outputs: Record<string, unknown>) => {
       setNodes((nds) => {
-        // Build a map of outgoing edges from this node
         const outgoingEdges = edges.filter(
           (e) => e.source === nodeId && e.sourceHandle && e.targetHandle
         );
@@ -335,8 +334,10 @@ export function useCanvasStore({
           const relevantEdges = outgoingEdges.filter((e) => e.target === n.id);
           if (relevantEdges.length === 0) return n;
 
-          // Build config patch for this downstream node
           const configPatch: Record<string, unknown> = {};
+          // Collect image UUIDs being propagated into this node
+          const incomingImageUuids: string[] = [];
+
           for (const edge of relevantEdges) {
             const outputKey = edge.sourceHandle!;
             const targetKey = edge.targetHandle!;
@@ -346,16 +347,37 @@ export function useCanvasStore({
             const value = Array.isArray(raw) ? raw[0] : raw;
             if (value !== undefined) {
               configPatch[targetKey] = String(value);
+              // Track image UUIDs so we can also update outputHistory
+              if (outputKey === "image_uuid") {
+                const uuids = Array.isArray(raw)
+                  ? (raw as string[])
+                  : [String(raw)];
+                incomingImageUuids.push(...uuids);
+              }
             }
           }
 
           if (Object.keys(configPatch).length === 0) return n;
+
+          // Build outputHistory patch if image UUIDs are flowing in
+          let nextHistory = (n.data.outputHistory as ImageBatch[] | undefined) ?? [];
+          if (incomingImageUuids.length > 0) {
+            const nextRunIndex =
+              nextHistory.length > 0
+                ? nextHistory[nextHistory.length - 1].runIndex + 1
+                : 0;
+            nextHistory = [
+              ...nextHistory,
+              { runIndex: nextRunIndex, imageUuids: incomingImageUuids },
+            ];
+          }
 
           return {
             ...n,
             data: {
               ...n.data,
               config: { ...n.data.config, ...configPatch },
+              outputHistory: nextHistory,
             },
           };
         });

--- a/frontend/src/features/canvas/hooks/useCanvasStore.ts
+++ b/frontend/src/features/canvas/hooks/useCanvasStore.ts
@@ -24,6 +24,7 @@ import type {
   NodeExecutionStatus,
   CanvasExecutionState,
   PortDef,
+  ImageBatch,
 } from "../types";
 import { runTemplate } from "@/lib/api/template-service";
 
@@ -282,6 +283,38 @@ export function useCanvasStore({
     [setNodes]
   );
 
+  /**
+   * Appends image UUIDs from a successful node execution as a new ImageBatch
+   * in node.data.outputHistory. Call this instead of (or in addition to)
+   * updateNodeData when outputs contain image_uuid arrays.
+   */
+  const appendNodeOutputHistory = useCallback(
+    (nodeId: string, outputs: Record<string, unknown>) => {
+      const imageUuids = (outputs.image_uuid as string[] | undefined) ?? [];
+      if (imageUuids.length === 0) return;
+
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (n.id !== nodeId) return n;
+          const existingHistory = (n.data.outputHistory as ImageBatch[]) ?? [];
+          const nextRunIndex =
+            existingHistory.length > 0
+              ? existingHistory[existingHistory.length - 1].runIndex + 1
+              : 0;
+          const newBatch: ImageBatch = { runIndex: nextRunIndex, imageUuids };
+          return {
+            ...n,
+            data: {
+              ...n.data,
+              outputHistory: [...existingHistory, newBatch],
+            },
+          };
+        })
+      );
+    },
+    [setNodes]
+  );
+
   const deleteSelectedElements = useCallback(() => {
     setNodes((nds) => nds.filter((n) => !n.selected));
     setEdges((eds) => eds.filter((e) => !e.selected));
@@ -387,6 +420,7 @@ export function useCanvasStore({
     deleteSelectedElements,
     updateNodeConfig,
     updateNodeData,
+    appendNodeOutputHistory,
     setNodeStatus,
 
     execution,

--- a/frontend/src/features/canvas/hooks/useCanvasStore.ts
+++ b/frontend/src/features/canvas/hooks/useCanvasStore.ts
@@ -315,6 +315,55 @@ export function useCanvasStore({
     [setNodes]
   );
 
+  /**
+   * After a node completes successfully, walk all outgoing edges from that
+   * node and push output values into each downstream node's config.
+   *
+   * Rule: outputs[sourceHandle] is typically an array — we take the first
+   * element and write it as a string into targetNode.data.config[targetHandle].
+   */
+  const propagateOutputsDownstream = useCallback(
+    (nodeId: string, outputs: Record<string, unknown>) => {
+      setNodes((nds) => {
+        // Build a map of outgoing edges from this node
+        const outgoingEdges = edges.filter(
+          (e) => e.source === nodeId && e.sourceHandle && e.targetHandle
+        );
+        if (outgoingEdges.length === 0) return nds;
+
+        return nds.map((n) => {
+          const relevantEdges = outgoingEdges.filter((e) => e.target === n.id);
+          if (relevantEdges.length === 0) return n;
+
+          // Build config patch for this downstream node
+          const configPatch: Record<string, unknown> = {};
+          for (const edge of relevantEdges) {
+            const outputKey = edge.sourceHandle!;
+            const targetKey = edge.targetHandle!;
+            const raw = outputs[outputKey];
+            if (raw === undefined) continue;
+            // Outputs are arrays from the backend — take the first element
+            const value = Array.isArray(raw) ? raw[0] : raw;
+            if (value !== undefined) {
+              configPatch[targetKey] = String(value);
+            }
+          }
+
+          if (Object.keys(configPatch).length === 0) return n;
+
+          return {
+            ...n,
+            data: {
+              ...n.data,
+              config: { ...n.data.config, ...configPatch },
+            },
+          };
+        });
+      });
+    },
+    [setNodes, edges]
+  );
+
   const deleteSelectedElements = useCallback(() => {
     setNodes((nds) => nds.filter((n) => !n.selected));
     setEdges((eds) => eds.filter((e) => !e.selected));
@@ -421,6 +470,7 @@ export function useCanvasStore({
     updateNodeConfig,
     updateNodeData,
     appendNodeOutputHistory,
+    propagateOutputsDownstream,
     setNodeStatus,
 
     execution,

--- a/frontend/src/features/canvas/types.ts
+++ b/frontend/src/features/canvas/types.ts
@@ -182,6 +182,20 @@ export type NodeExecutionStatus =
 /** Category tag used for colour-coding and grouping in the node library */
 export type NodeCategory = "text" | "image" | "video" | "utility";
 
+/** The three view modes for the node image gallery */
+export type ImageViewMode = "single" | "batch" | "all";
+
+/**
+ * One execution run's worth of output image UUIDs.
+ * A batch is created each time the node runs successfully.
+ */
+export interface ImageBatch {
+  /** Monotonically-increasing index — used as React key and for display */
+  runIndex: number;
+  /** Ordered list of image GUIDs produced in this run */
+  imageUuids: string[];
+}
+
 export interface CanvasNodeData {
   // Index signature required by @xyflow/react Node<T extends Record<string, unknown>>
   [key: string]: unknown;
@@ -203,6 +217,11 @@ export interface CanvasNodeData {
   errorMessage?: string;
   /** Output values populated after successful execution */
   outputValues?: Record<string, unknown>;
+  /**
+   * Accumulated image history across all runs.
+   * Each entry is one batch (one press of "Run Model").
+   */
+  outputHistory?: ImageBatch[];
   // ---------------------------------------------------------------------------
   // Runtime callbacks — injected by the canvas page at render time.
   // Typed as unknown to satisfy the index signature; components cast them.


### PR DESCRIPTION
## Multi-Image Node Gallery & Media Management

### Canvas — Multi-image gallery
- Added `outputHistory` tracking per node to store all previously generated images across runs
- Replaced single-image previews in `PreviewNode` and `ImportMediaNode` with a reusable `NodeImageGallery` component
- `NodeImageGallery` supports three view modes: **Single** (prev/next navigation), **Batch** (grouped by run), **All** (full grid)
- Added fullscreen overlay via `FullscreenGallery` with thumbnail strip and keyboard/click navigation
- Implemented downstream propagation — output images automatically populate connected nodes' galleries
- `ImportMediaNode` falls back to `config.image_uuid` to seed its gallery when no run history exists

### URL resolution fix
- Added `resolveImgUrl` helper to `NodeImageGallery`, `FullscreenGallery`, and `GeneratedMediaPanel` — correctly handles both full `https://` URLs (ambassador/imported assets) and bare GUIDs (generated outputs), preventing broken image links

### Generated Media sidebar panel
- Added a new **Generated Media** tab to the canvas sidebar (`GeneratedMediaPanel`)
- Displays a timeline-grouped view of all intermediate images generated across all canvas nodes
- Click-to-fullscreen and "View all" mode; live-updating as workflows run

### Assets page redesign
- Time-grouped asset grid: **Today / Yesterday / Previous 7 days / This month / Older**
- Richer asset cards: hover-to-play for video, type badges, scale animation, consistent dark theme
- Asset detail page: metadata sidebar (template link, date, type, publication count), analytics stat row (pre-wired for future API), improved publication cards with live SignalR status updates
- Fixed background color on both assets pages to use app theme token (`bg-background`)

closes #225 
closes #236
closes #234
closes #235 