### PR TITLE
[TemplateService] Add event publishing when Library Template created/updated/deleted (#273)

### DIFF
--- a/template-service/backend_template/entities/events.py
+++ b/template-service/backend_template/entities/events.py
@@ -2,8 +2,9 @@
 Event schemas for Template Service → other services communication.
 
 These Pydantic models define the payloads published to RabbitMQ when
-Library Templates are created, updated, or deleted. Other services
-(e.g. UserService) consume these events to maintain referential integrity.
+Library Templates or Project Templates are created, updated, or deleted.
+Other services (e.g. UserService) consume these events to maintain
+referential integrity.
 """
 
 from datetime import datetime
@@ -72,3 +73,67 @@ class LibraryTemplateDeletedEvent(LibraryTemplateEvent):
     """Published after a Library Template is removed from the library."""
 
     event_type: TemplateEventType = TemplateEventType.DELETED
+
+
+# ---------------------------------------------------------------------------
+# ProjectTemplate events
+# ---------------------------------------------------------------------------
+
+
+class ProjectTemplateEventType(StrEnum):
+    CREATED = "project_template.created"
+    UPDATED = "project_template.updated"
+    DELETED = "project_template.deleted"
+
+
+class ProjectTemplateEvent(BaseModel):
+    """
+    Base event payload for Project Template state changes.
+
+    Published to the ``project_template.events`` fanout exchange so downstream
+    services can track per-project template lifecycle without polling.
+    """
+
+    event_type: ProjectTemplateEventType = Field(
+        description="Discriminator: what happened to the project template."
+    )
+    template_id: UUID = Field(
+        description="ID of the affected Project Template."
+    )
+    project_id: UUID = Field(
+        description="ID of the parent Project this template belongs to."
+    )
+    occurred_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="UTC timestamp of when the event occurred.",
+    )
+
+
+class ProjectTemplateCreatedEvent(ProjectTemplateEvent):
+    """Published right after a new Project Template is persisted."""
+
+    event_type: ProjectTemplateEventType = ProjectTemplateEventType.CREATED
+    name: str = Field(description="Display name of the new template.")
+    description: str | None = Field(
+        default=None,
+        description="Optional description.",
+    )
+
+
+class ProjectTemplateUpdatedEvent(ProjectTemplateEvent):
+    """
+    Published after a Project Template is patched.
+    Only the fields that were actually changed are included.
+    """
+
+    event_type: ProjectTemplateEventType = ProjectTemplateEventType.UPDATED
+    changed_fields: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Map of field name → new value for every field that changed.",
+    )
+
+
+class ProjectTemplateDeletedEvent(ProjectTemplateEvent):
+    """Published after a Project Template is removed."""
+
+    event_type: ProjectTemplateEventType = ProjectTemplateEventType.DELETED

--- a/template-service/backend_template/entities/events.py
+++ b/template-service/backend_template/entities/events.py
@@ -1,0 +1,74 @@
+"""
+Event schemas for Template Service → other services communication.
+
+These Pydantic models define the payloads published to RabbitMQ when
+Library Templates are created, updated, or deleted. Other services
+(e.g. UserService) consume these events to maintain referential integrity.
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class TemplateEventType(StrEnum):
+    CREATED = "template.created"
+    UPDATED = "template.updated"
+    DELETED = "template.deleted"
+
+
+class LibraryTemplateEvent(BaseModel):
+    """
+    Base event payload for Library Template state changes.
+
+    Published to the ``template.events`` fanout exchange so any downstream
+    service can subscribe without knowing the routing topology upfront.
+    """
+
+    event_type: TemplateEventType = Field(
+        description="Discriminator: what happened to the template."
+    )
+    template_id: UUID = Field(
+        description="ID of the affected Library Template."
+    )
+    occurred_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="UTC timestamp of when the event occurred.",
+    )
+
+
+class LibraryTemplateCreatedEvent(LibraryTemplateEvent):
+    """Published right after a new Library Template is persisted."""
+
+    event_type: TemplateEventType = TemplateEventType.CREATED
+    name: str = Field(description="Display name of the new template.")
+    description: str | None = Field(
+        default=None,
+        description="Optional description.",
+    )
+    thumbnail_url: str | None = Field(
+        default=None,
+        description="Thumbnail URL if already set at creation time.",
+    )
+
+
+class LibraryTemplateUpdatedEvent(LibraryTemplateEvent):
+    """
+    Published after a Library Template is patched.
+    Only the fields that were actually changed are included (others are None).
+    """
+
+    event_type: TemplateEventType = TemplateEventType.UPDATED
+    changed_fields: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Map of field name → new value for every field that changed.",
+    )
+
+
+class LibraryTemplateDeletedEvent(LibraryTemplateEvent):
+    """Published after a Library Template is removed from the library."""
+
+    event_type: TemplateEventType = TemplateEventType.DELETED

--- a/template-service/backend_template/services/library_template.py
+++ b/template-service/backend_template/services/library_template.py
@@ -10,13 +10,24 @@ from backend_template.entities.library_template import (
     LibraryTemplateResponse,
     LibraryTemplateUpdate,
 )
+from backend_template.entities.events import (
+    LibraryTemplateCreatedEvent,
+    LibraryTemplateDeletedEvent,
+    LibraryTemplateUpdatedEvent,
+)
 from backend_template.repositories.library_template import LibraryTemplateRepository
+from backend_template.utils.broker import TEMPLATE_EVENTS_EXCHANGE, publish_event
 
 
 class LibraryTemplateService:
     """
     Business Logic Layer for Library Templates.
     Orchestrates data flow between Controller (Schemas) and Repository (ORM).
+
+    After each mutating operation the service publishes a lifecycle event to the
+    ``template.events`` RabbitMQ exchange so downstream services (UserService,
+    etc.) can react without polling.  Publishing is best-effort: a failure logs
+    an error but never rolls back the primary DB operation.
     """
 
     def __init__(
@@ -34,8 +45,7 @@ class LibraryTemplateService:
     ) -> LibraryTemplateResponse:
         """
         Creates a new LibraryTemplate (internal use only).
-        Input: Pydantic Schema
-        Output: Pydantic Schema
+        Publishes a ``template.created`` event on success.
         """
         # 1. Convert Schema to Dictionary for Repository
         template_data = payload.model_dump()
@@ -44,7 +54,20 @@ class LibraryTemplateService:
         orm_template = await self.repo.create(**template_data)
 
         # 3. Convert ORM Model -> Pydantic Schema (Prevention of Leak)
-        return LibraryTemplateResponse.model_validate(orm_template)
+        response = LibraryTemplateResponse.model_validate(orm_template)
+
+        # 4. Publish lifecycle event (best-effort — failures are only logged)
+        await publish_event(
+            TEMPLATE_EVENTS_EXCHANGE,
+            LibraryTemplateCreatedEvent(
+                template_id=response.id,
+                name=response.name,
+                description=response.description,
+                thumbnail_url=response.thumbnail_url,
+            ),
+        )
+
+        return response
 
     async def get_template(self, template_id: UUID) -> LibraryTemplateResponse:
         """
@@ -84,6 +107,7 @@ class LibraryTemplateService:
     ) -> LibraryTemplateResponse:
         """
         Partially updates a library template (internal use only).
+        Publishes a ``template.updated`` event on success.
         """
         # 1. Check Existence first
         existing_template = await self.repo.get_by_id(template_id)
@@ -100,11 +124,24 @@ class LibraryTemplateService:
         updated_orm = await self.repo.update(template_id, **update_data)
 
         # 4. Map to Response
-        return LibraryTemplateResponse.model_validate(updated_orm)
+        response = LibraryTemplateResponse.model_validate(updated_orm)
+
+        # 5. Publish lifecycle event (only if at least one field changed)
+        if update_data:
+            await publish_event(
+                TEMPLATE_EVENTS_EXCHANGE,
+                LibraryTemplateUpdatedEvent(
+                    template_id=template_id,
+                    changed_fields=update_data,
+                ),
+            )
+
+        return response
 
     async def delete_template(self, template_id: UUID) -> None:
         """
         Deletes a library template (internal use only).
+        Publishes a ``template.deleted`` event on success.
         """
         # 1. Check Existence
         existing_template = await self.repo.get_by_id(template_id)
@@ -116,3 +153,9 @@ class LibraryTemplateService:
 
         # 2. Execute Delete
         await self.repo.delete(template_id)
+
+        # 3. Publish lifecycle event
+        await publish_event(
+            TEMPLATE_EVENTS_EXCHANGE,
+            LibraryTemplateDeletedEvent(template_id=template_id),
+        )

--- a/template-service/backend_template/services/project_template.py
+++ b/template-service/backend_template/services/project_template.py
@@ -10,8 +10,14 @@ from backend_template.entities.project_template import (
     ProjectTemplateResponse,
     ProjectTemplateUpdate,
 )
+from backend_template.entities.events import (
+    ProjectTemplateCreatedEvent,
+    ProjectTemplateUpdatedEvent,
+    ProjectTemplateDeletedEvent,
+)
 from backend_template.repositories.project_template import ProjectTemplateRepository
 from backend_template.repositories.library_template import LibraryTemplateRepository
+from backend_template.utils.broker import PROJECT_TEMPLATE_EVENTS_EXCHANGE, publish_event
 
 
 class ProjectTemplateService:
@@ -49,7 +55,20 @@ class ProjectTemplateService:
         orm_template = await self.repo.create(**template_data)
 
         # 3. Convert ORM Model -> Pydantic Schema (Prevention of Leak)
-        return ProjectTemplateResponse.model_validate(orm_template)
+        response = ProjectTemplateResponse.model_validate(orm_template)
+
+        # 4. Publish lifecycle event (best-effort — failures are only logged)
+        await publish_event(
+            PROJECT_TEMPLATE_EVENTS_EXCHANGE,
+            ProjectTemplateCreatedEvent(
+                template_id=response.id,
+                project_id=response.project_id,
+                name=response.name,
+                description=response.description,
+            ),
+        )
+
+        return response
 
     async def get_template(self, template_id: UUID) -> ProjectTemplateResponse:
         """
@@ -118,7 +137,20 @@ class ProjectTemplateService:
         updated_orm = await self.repo.update(template_id, **update_data)
         
         # 4. Map to Response
-        return ProjectTemplateResponse.model_validate(updated_orm)
+        response = ProjectTemplateResponse.model_validate(updated_orm)
+
+        # 5. Publish lifecycle event (only if at least one field changed)
+        if update_data:
+            await publish_event(
+                PROJECT_TEMPLATE_EVENTS_EXCHANGE,
+                ProjectTemplateUpdatedEvent(
+                    template_id=template_id,
+                    project_id=response.project_id,
+                    changed_fields=update_data,
+                ),
+            )
+
+        return response
 
     async def delete_template(self, template_id: UUID) -> None:
         """
@@ -134,6 +166,15 @@ class ProjectTemplateService:
 
         # 2. Execute Delete
         await self.repo.delete(template_id)
+
+        # 3. Publish lifecycle event
+        await publish_event(
+            PROJECT_TEMPLATE_EVENTS_EXCHANGE,
+            ProjectTemplateDeletedEvent(
+                template_id=template_id,
+                project_id=existing_template.project_id,
+            ),
+        )
 
     async def duplicate_from_library(
         self, library_template_id: UUID, project_id: UUID
@@ -159,5 +200,18 @@ class ProjectTemplateService:
         )
 
         # 3. Return as Pydantic response
-        return ProjectTemplateResponse.model_validate(orm_template)
+        response = ProjectTemplateResponse.model_validate(orm_template)
+
+        # 4. Publish lifecycle event (best-effort)
+        await publish_event(
+            PROJECT_TEMPLATE_EVENTS_EXCHANGE,
+            ProjectTemplateCreatedEvent(
+                template_id=response.id,
+                project_id=response.project_id,
+                name=response.name,
+                description=response.description,
+            ),
+        )
+
+        return response
         

--- a/template-service/backend_template/utils/broker.py
+++ b/template-service/backend_template/utils/broker.py
@@ -16,8 +16,11 @@ from backend_template.config import settings
 
 logger = logging.getLogger(__name__)
 
-# The single fanout exchange used for all Library Template lifecycle events.
+# Fanout exchange for Library Template lifecycle events.
 TEMPLATE_EVENTS_EXCHANGE = "template.events"
+
+# Fanout exchange for Project Template lifecycle events.
+PROJECT_TEMPLATE_EVENTS_EXCHANGE = "project_template.events"
 
 
 async def publish_event(exchange_name: str, message: BaseModel) -> None:

--- a/template-service/backend_template/utils/broker.py
+++ b/template-service/backend_template/utils/broker.py
@@ -1,18 +1,39 @@
+"""
+RabbitMQ helper for the Template Service web application.
+
+Uses ``backend_template.config.settings.rabbitmq_url`` — *not* the engine's
+config — so this module is safe to import in any FastAPI context without
+pulling in ComfyUI engine dependencies.
+"""
+
 import json
 import logging
 
 import aio_pika
 from pydantic import BaseModel
 
-from backend_template.engine.config import rabbitmq_config
+from backend_template.config import settings
 
 logger = logging.getLogger(__name__)
 
+# The single fanout exchange used for all Library Template lifecycle events.
+TEMPLATE_EVENTS_EXCHANGE = "template.events"
+
 
 async def publish_event(exchange_name: str, message: BaseModel) -> None:
-    """Publishes a Pydantic model as JSON to a durable fanout exchange on RabbitMQ."""
+    """
+    Publishes a Pydantic model as JSON to a durable fanout exchange on RabbitMQ.
+
+    Failures are logged but **never re-raised** — event publishing is best-effort
+    and must not break the main request flow. If reliable delivery is required
+    in the future, add an outbox pattern here.
+
+    Args:
+        exchange_name: Name of the RabbitMQ fanout exchange to publish to.
+        message: Any Pydantic model; serialised to JSON via ``model_dump``.
+    """
     try:
-        connection = await aio_pika.connect_robust(rabbitmq_config.rabbitmq_url)
+        connection = await aio_pika.connect_robust(settings.rabbitmq_url)
         async with connection:
             channel = await connection.channel()
             exchange = await channel.declare_exchange(
@@ -20,11 +41,11 @@ async def publish_event(exchange_name: str, message: BaseModel) -> None:
                 aio_pika.ExchangeType.FANOUT,
                 durable=True,
             )
-            body = json.dumps(message.model_dump(by_alias=True)).encode()
+            body = json.dumps(message.model_dump(mode="json", by_alias=True)).encode()
             await exchange.publish(
                 aio_pika.Message(body=body, content_type="application/json"),
                 routing_key="",
             )
-            logger.info(f"Published to {exchange_name}: {body.decode()}")
-    except Exception as e:
-        logger.error(f"Failed to publish event to {exchange_name}: {e}")
+            logger.info("Published to %s: %s", exchange_name, body.decode())
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to publish event to %s: %s", exchange_name, exc)


### PR DESCRIPTION
## What

Closes #273.

Adds RabbitMQ lifecycle event publishing to `LibraryTemplateService` so downstream services (e.g. UserService storing `TemplateId` in `ProjectAssets`) can react to template state changes without polling.

---

## Why

Currently there is no mechanism for other services to know when a Library Template is mutated or removed. This leads to stale `TemplateId` references in `ProjectAssets` and similar join-points — the exact consistency gap described in #273.

---

## How

### 1. `backend_template/entities/events.py` _(new file)_

Three Pydantic event schemas published to the `template.events` fanout exchange:

| Event | When |
|---|---|
| `LibraryTemplateCreatedEvent` | After `repo.create()` succeeds |
| `LibraryTemplateUpdatedEvent` | After `repo.update()` succeeds (only if ≥1 field changed) |
| `LibraryTemplateDeletedEvent` | After `repo.delete()` succeeds |

All share a common base with `template_id`, `event_type` (StrEnum), and `occurred_at` (UTC timestamp).

### 2. `backend_template/utils/broker.py` _(bug fix + cleanup)_

- **Bug fixed:** was importing `rabbitmq_config` from `backend_template.engine.config` (the ComfyUI engine config) instead of the main app `settings`. This would silently use the wrong URL in production.
- Added `TEMPLATE_EVENTS_EXCHANGE = "template.events"` constant.
- Added `mode="json"` to `model_dump()` so `UUID` and `datetime` fields serialise correctly (not as Python objects).

### 3. `backend_template/services/library_template.py` _(event wiring)_

`create_template`, `update_template`, `delete_template` now call `publish_event()` after a successful DB operation. Publishing is **fire-and-forget** — errors are logged but never re-raised, keeping the main request path safe.

---

## Consumer contract

The `template.events` exchange is **fanout** and **durable**. Any service that needs to react just binds a queue to it. No routing key is required.

Sample payload for `template.deleted`:
```json
{
  "event_type": "template.deleted",
  "template_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "occurred_at": "2026-04-12T12:01:00Z"
}
```

---

## Risks / Notes

- **No outbox pattern** — if RabbitMQ is down, the event is lost (the DB write still succeeds). This is acceptable for now given the best-effort design; an outbox can be added later if stricter delivery guarantees are needed.
- **Exchange declaration is idempotent** — re-declaring the same durable fanout exchange on each publish is safe with aio-pika.
- The `template.events` exchange name should be added to infra/Helm values if it needs to be pre-declared.