### PR TITLE
fix(template-service): fail job on graph validation errors (#287)

### DIFF
--- a/template-service/backend_template/services/job.py
+++ b/template-service/backend_template/services/job.py
@@ -104,6 +104,25 @@ class JobService:
                         job.status = JobStatus.FAILED
                         await self.db.commit()
                         raise HTTPException(status_code=resp.status, detail=body)
+
+                    # The engine returns HTTP 200 even when some nodes fail
+                    # validation (partial execution). Treat any node_errors as a
+                    # hard failure so the graph is never run in a broken state.
+                    node_errors: dict = body.get("node_errors") or {}
+                    if node_errors:
+                        job.status = JobStatus.FAILED
+                        await self.db.commit()
+                        logger.warning(
+                            f"Graph validation failed for job {job.id}: {node_errors}"
+                        )
+                        raise HTTPException(
+                            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail={
+                                "error": "Graph validation failed",
+                                "node_errors": node_errors,
+                            },
+                        )
+
                     prompt_id: str = body["prompt_id"]
         except aiohttp.ClientConnectorError:
             job.status = JobStatus.FAILED

--- a/template-service/backend_template/web/routes/http/v1/engine.py
+++ b/template-service/backend_template/web/routes/http/v1/engine.py
@@ -74,6 +74,11 @@ async def run_template(
     Job + NodeExecution records, submits the graph to ComfyUI, and streams
     node status updates via RabbitMQ → WebSocket Gateway → frontend.
     Returns immediately with job_id and prompt_id.
+
+    Raises **422 Unprocessable Entity** if the graph contains validation
+    errors (e.g. missing required inputs, type mismatches).  The response
+    body includes a structured ``node_errors`` dict so the frontend can
+    highlight the broken nodes.
     """
     return await service.run_template(payload.template_id, user_id=user_id)
 


### PR DESCRIPTION
## Problem

Closes #287

The ComfyUI engine runs `validate_prompt()` before queueing a workflow. When **some** output nodes fail validation but **at least one** passes, the engine still returns **HTTP 200** — with a non-empty `node_errors` field — and runs the graph with only the valid nodes.

`JobService.run_template` was not checking `node_errors` on the 200 response, so a broken graph would:
1. Silently start execution
2. Only run the valid subset of nodes
3. Appear to the user as if it succeeded (job status → `PROCESSING`)

## Fix

After receiving a successful (200) response from the engine, check `node_errors`:
- If **non-empty** → mark the `Job` as `FAILED`, log the errors, and raise **HTTP 422 Unprocessable Entity** with a structured body.
- If **empty** → proceed normally.

### Response body on validation failure
```json
{
  "error": "Graph validation failed",
  "node_errors": {
    "<node_id>": {
      "errors": [
        {
          "type": "required_input_missing",
          "message": "Required input is missing",
          "details": "<input_name>"
        }
      ],
      "class_type": "GeminiNode",
      "dependent_outputs": ["<output_node_id>"]
    }
  }
}
```

This gives the frontend a clear, structured signal to highlight the broken nodes instead of showing a silently-broken execution.

## Changes

| File | Change |
|---|---|
| `services/job.py` | Check `node_errors` after engine 200; fail early with HTTP 422 |
| `web/routes/http/v1/engine.py` | Add 422 docs to `/engine/run` endpoint |

## Testing

Manual:
1. Create a template with an intentionally misconfigured node (e.g., missing a required connection).
2. Call `POST /engine/run`.
3. **Before**: job starts, runs partially, no clear error.  
4. **After**: job is immediately marked `FAILED`, API returns 422 with `node_errors` detail.