### PR TITLE
feat(frontend): add AmplifyVideo component (#292)

### DIFF
--- a/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/[assetId]/page.tsx
@@ -4,14 +4,13 @@
 // AssetDetailPage — Full view of a single generated asset
 // =============================================================================
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import {
   ArrowLeft,
   ImageIcon,
   Video,
-  Play,
   FileQuestion,
   Send,
   Loader2,
@@ -36,6 +35,7 @@ import type { ProjectAsset, PublicationRecord } from "@/features/ambassadors/typ
 import { getTemplateV1TemplatesTemplateIdGet } from "@/lib/api/template-service";
 import { useHubConnection } from "@/hooks/useHubConnection";
 import { AmplifyImage } from "@/features/media/components/AmplifyImage";
+import { AmplifyVideo } from "@/features/media/components/AmplifyVideo";
 
 type TemplateMeta = { id: string; name: string } | null | undefined;
 
@@ -251,8 +251,6 @@ export default function AssetDetailPage() {
   const [records, setRecords] = useState<PublicationRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [videoPlaying, setVideoPlaying] = useState(false);
-  const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     if (!assetId) return;
@@ -347,32 +345,12 @@ export default function AssetDetailPage() {
                   isVideo ? "aspect-video" : "aspect-video"
                 )}>
                   {isVideo ? (
-                    <>
-                      <video
-                        ref={videoRef}
-                        src={asset.mediaUrl}
-                        className="w-full h-full object-contain"
-                        preload="none"
-                        playsInline
-                        controls={videoPlaying}
-                        onEnded={() => setVideoPlaying(false)}
-                      />
-                      <AnimatePresence>
-                        {!videoPlaying && (
-                          <motion.button
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            onClick={() => { setVideoPlaying(true); videoRef.current?.play(); }}
-                            className="absolute inset-0 flex items-center justify-center group"
-                          >
-                            <div className="w-16 h-16 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 flex items-center justify-center group-hover:bg-black/80 group-hover:scale-110 transition-all duration-200">
-                              <Play className="w-6 h-6 text-white ml-0.5" />
-                            </div>
-                          </motion.button>
-                        )}
-                      </AnimatePresence>
-                    </>
+                    <AmplifyVideo
+                      src={asset.mediaUrl}
+                      mode="click-play"
+                      lightbox
+                      className="object-contain"
+                    />
                   ) : (
                     <AmplifyImage 
                       mediaId={asset.mediaId}

--- a/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/assets/page.tsx
@@ -21,6 +21,7 @@ import { useProjects } from "@/features/ambassadors/hooks/useProjects";
 import { useProjectAssets } from "@/features/ambassadors/hooks/useProjectAssets";
 import type { ProjectAsset } from "@/features/ambassadors/types";
 import { AmplifyImage } from "@/features/media/components/AmplifyImage";
+import { AmplifyVideo } from "@/features/media/components/AmplifyVideo";
 
 // ---------------------------------------------------------------------------
 // Time-group helpers
@@ -85,18 +86,10 @@ function AssetCard({ asset, projectId }: { asset: ProjectAsset; projectId: strin
       {/* Media */}
       <div className="aspect-video relative overflow-hidden bg-black/40">
         {isVideo ? (
-          <video
+          <AmplifyVideo
             src={asset.mediaUrl}
-            className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
-            muted
-            playsInline
-            preload="metadata"
-            onMouseEnter={(e) => (e.currentTarget as HTMLVideoElement).play()}
-            onMouseLeave={(e) => {
-              const v = e.currentTarget as HTMLVideoElement;
-              v.pause();
-              v.currentTime = 0;
-            }}
+            mode="hover-play"
+            className="transition-transform duration-500 group-hover:scale-[1.03]"
           />
         ) : (
           <AmplifyImage

--- a/frontend/src/features/canvas/components/ImportMediaNode.tsx
+++ b/frontend/src/features/canvas/components/ImportMediaNode.tsx
@@ -19,17 +19,7 @@ import { cn } from "@/lib/utils";
 import type { CanvasNode, ImageBatch } from "../types";
 import { NodePort } from "./NodePort";
 import { NodeImageGallery } from "./NodeImageGallery";
-
-// ---------------------------------------------------------------------------
-// Media URL helper
-// ---------------------------------------------------------------------------
-
-function getMediaUrl(uuidOrUrl: string): string {
-  if (uuidOrUrl.startsWith("http://") || uuidOrUrl.startsWith("https://")) return uuidOrUrl;
-  const base =
-    process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://staging.alexeykiselev.tech";
-  return `${base}/media/api/media/${uuidOrUrl}`;
-}
+import { AmplifyVideo } from "@/features/media/components/AmplifyVideo";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -163,16 +153,15 @@ function EmptyMediaPreview() {
 }
 
 function VideoPreview({ uuid }: { uuid: string }) {
-  const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
+  // Accept either a bare UUID (resolved via media-ingest proxy) or a full URL
+  const isUuid = !uuid.startsWith("http://") && !uuid.startsWith("https://");
 
   return (
     <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video mb-2">
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
-        src={url}
-        controls
-        className="nodrag w-full h-full object-contain"
-        preload="metadata"
+      <AmplifyVideo
+        {...(isUuid ? { mediaId: uuid } : { src: uuid })}
+        mode="controls"
+        className="nodrag"
       />
     </div>
   );

--- a/frontend/src/features/canvas/components/MediaAssetsPanel.tsx
+++ b/frontend/src/features/canvas/components/MediaAssetsPanel.tsx
@@ -250,7 +250,12 @@ function AssetCard({
       {/* Thumbnail */}
       {isVideo ? (
         <div className="relative w-full h-full bg-black">
-          {/* Real video thumbnail — browser loads first frame from metadata */}
+          {/*
+           * Intentional raw <video> — used only as a static thumbnail extractor.
+           * preload="metadata" + onLoadedMetadata seek gives us the first frame
+           * without triggering playback. AmplifyVideo is for interactive playback;
+           * it doesn't expose this thumbnail-scrape pattern.
+           */}
           <video
             src={mediaApi.getMediaUrl(asset.mediaId)}
             className="w-full h-full object-cover"

--- a/frontend/src/features/canvas/components/PreviewNode.tsx
+++ b/frontend/src/features/canvas/components/PreviewNode.tsx
@@ -22,6 +22,7 @@ import {
   Maximize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { AmplifyVideo } from "@/features/media/components/AmplifyVideo";
 import type { CanvasNode, ImageBatch } from "../types";
 import { NodePort } from "./NodePort";
 import { NodeImageGallery } from "./NodeImageGallery";
@@ -213,16 +214,15 @@ function TextPreview({ value }: { value: string }) {
 }
 
 function VideoPreview({ uuid }: { uuid: string }) {
-  const url = uuid.startsWith("http") ? uuid : getMediaUrl(uuid);
+  // Accept either a bare UUID (resolved via media-ingest proxy) or a full URL
+  const isUuid = !uuid.startsWith("http://") && !uuid.startsWith("https://");
 
   return (
-    <div className="rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video">
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
-        src={url}
-        controls
-        className="nodrag w-full h-full object-contain"
-        preload="metadata"
+    <div className="relative rounded-lg overflow-hidden bg-black/25 border border-white/[0.06] aspect-video">
+      <AmplifyVideo
+        {...(isUuid ? { mediaId: uuid } : { src: uuid })}
+        mode="controls"
+        className="nodrag"
       />
     </div>
   );

--- a/frontend/src/features/media/components/AmplifyVideo.tsx
+++ b/frontend/src/features/media/components/AmplifyVideo.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { X, Play, Volume2, VolumeX } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { mediaApi } from "@/features/media/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * How the video reacts to user interaction:
+ *
+ * - `"hover-play"` — muted autoplay on pointer enter, pause+rewind on leave.
+ *   Great for thumbnails / gallery cards.
+ * - `"click-play"` — shows a play-button overlay; user clicks to play in place.
+ *   Ideal for asset detail pages.
+ * - `"controls"` — native <video controls>. Best for preview nodes.
+ */
+export type VideoMode = "hover-play" | "click-play" | "controls";
+
+export interface AmplifyVideoProps {
+  /**
+   * Media UUID — component resolves /media/{id} automatically.
+   * Use this when displaying media managed by media-ingest.
+   */
+  mediaId?: string;
+
+  /**
+   * Direct URL — use when the URL is already resolved externally.
+   * When provided, mediaId is ignored.
+   */
+  src?: string;
+
+  /**
+   * Media UUID to use as the video poster / thumbnail.
+   * Auto-resolved to the "Medium" variant.
+   */
+  thumbnailId?: string;
+
+  /**
+   * Direct URL for the poster image.
+   * When provided, thumbnailId is ignored.
+   */
+  thumbnailSrc?: string;
+
+  /**
+   * Interaction mode. Defaults to `"click-play"`.
+   */
+  mode?: VideoMode;
+
+  /**
+   * Open a fullscreen player on click.
+   * Only applies when mode is `"click-play"` or `"hover-play"`.
+   * When true, clicking opens the lightbox instead of playing in place.
+   */
+  lightbox?: boolean;
+
+  /** Mute the video. Default: true for `hover-play`, false otherwise. */
+  muted?: boolean;
+
+  /** Loop the video. Default: false. */
+  loop?: boolean;
+
+  className?: string;
+  onLoad?: () => void;
+  onError?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildPoster(
+  thumbnailId?: string,
+  thumbnailSrc?: string
+): string | undefined {
+  if (thumbnailSrc) return thumbnailSrc;
+  if (thumbnailId) return mediaApi.getMediaUrl(thumbnailId, "Medium");
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Lightbox Portal
+// ---------------------------------------------------------------------------
+
+function VideoLightboxPortal({
+  src,
+  poster,
+  onClose,
+}: {
+  src: string;
+  poster?: string;
+  onClose: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [muted, setMuted] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // Auto-play when portal opens
+  useEffect(() => {
+    videoRef.current?.play().catch(() => {
+      /* autoplay may be blocked — user can click Play */
+    });
+  }, []);
+
+  return createPortal(
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        className="fixed inset-0 z-[200] flex items-center justify-center bg-black/90 backdrop-blur-sm"
+        onClick={onClose}
+      >
+        {/* Close button */}
+        <button
+          className="absolute top-4 right-4 flex items-center justify-center w-9 h-9 rounded-xl bg-white/10 hover:bg-white/20 border border-white/10 text-white transition-colors z-10"
+          onClick={onClose}
+        >
+          <X className="w-4 h-4" />
+        </button>
+
+        {/* Mute toggle */}
+        <button
+          className="absolute top-4 right-16 flex items-center justify-center w-9 h-9 rounded-xl bg-white/10 hover:bg-white/20 border border-white/10 text-white transition-colors z-10"
+          onClick={(e) => {
+            e.stopPropagation();
+            setMuted((m) => !m);
+          }}
+        >
+          {muted ? (
+            <VolumeX className="w-4 h-4" />
+          ) : (
+            <Volume2 className="w-4 h-4" />
+          )}
+        </button>
+
+        {/* Video — stop propagation so clicking it doesn't close */}
+        <div
+          className="relative max-w-[90vw] max-h-[90vh] w-full flex items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={videoRef}
+            src={src}
+            poster={poster}
+            muted={muted}
+            controls
+            playsInline
+            className="max-w-full max-h-[90vh] rounded-xl shadow-2xl bg-black"
+          />
+        </div>
+      </motion.div>
+    </AnimatePresence>,
+    document.body
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HoverPlay implementation
+// ---------------------------------------------------------------------------
+
+function HoverPlayVideo({
+  src,
+  poster,
+  muted,
+  loop,
+  lightbox,
+  className,
+  onLoad,
+  onError,
+}: {
+  src: string;
+  poster?: string;
+  muted: boolean;
+  loop: boolean;
+  lightbox: boolean;
+  className?: string;
+  onLoad?: () => void;
+  onError?: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  const handleMouseEnter = () => {
+    if (lightbox) return; // don't autoplay if click opens lightbox
+    videoRef.current?.play().catch(() => {});
+  };
+
+  const handleMouseLeave = () => {
+    if (lightbox) return;
+    const v = videoRef.current;
+    if (!v) return;
+    v.pause();
+    v.currentTime = 0;
+  };
+
+  const handleClick = () => {
+    if (lightbox) setLightboxOpen(true);
+  };
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video
+        ref={videoRef}
+        src={src}
+        poster={poster}
+        muted={muted}
+        loop={loop}
+        playsInline
+        preload="metadata"
+        className={cn(
+          "absolute inset-0 h-full w-full object-cover",
+          lightbox && "cursor-zoom-in",
+          className
+        )}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
+        onLoadedData={onLoad}
+        onError={onError}
+      />
+
+      {lightboxOpen && (
+        <VideoLightboxPortal
+          src={src}
+          poster={poster}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ClickPlay implementation
+// ---------------------------------------------------------------------------
+
+function ClickPlayVideo({
+  src,
+  poster,
+  muted,
+  loop,
+  lightbox,
+  className,
+  onLoad,
+  onError,
+}: {
+  src: string;
+  poster?: string;
+  muted: boolean;
+  loop: boolean;
+  lightbox: boolean;
+  className?: string;
+  onLoad?: () => void;
+  onError?: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  const handleClick = () => {
+    if (lightbox) {
+      setLightboxOpen(true);
+      return;
+    }
+    const v = videoRef.current;
+    if (!v) return;
+    if (playing) {
+      v.pause();
+      setPlaying(false);
+    } else {
+      v.play().catch(() => {});
+      setPlaying(true);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={cn(
+          "absolute inset-0 h-full w-full cursor-pointer",
+          className
+        )}
+        onClick={handleClick}
+      >
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={videoRef}
+          src={src}
+          poster={poster}
+          muted={muted}
+          loop={loop}
+          playsInline
+          preload="metadata"
+          controls={false}
+          className="h-full w-full object-cover"
+          onLoadedData={onLoad}
+          onError={onError}
+          onEnded={() => setPlaying(false)}
+        />
+
+        {/* Play / Pause overlay */}
+        <AnimatePresence>
+          {!playing && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <div className="w-14 h-14 rounded-full bg-black/60 backdrop-blur-sm border border-white/20 flex items-center justify-center hover:bg-black/80 hover:scale-110 transition-all duration-200">
+                <Play className="w-5 h-5 text-white ml-0.5" fill="white" />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {lightboxOpen && (
+        <VideoLightboxPortal
+          src={src}
+          poster={poster}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Controls implementation
+// ---------------------------------------------------------------------------
+
+function ControlsVideo({
+  src,
+  poster,
+  muted,
+  loop,
+  className,
+  onLoad,
+  onError,
+}: {
+  src: string;
+  poster?: string;
+  muted: boolean;
+  loop: boolean;
+  className?: string;
+  onLoad?: () => void;
+  onError?: () => void;
+}) {
+  return (
+    // eslint-disable-next-line jsx-a11y/media-has-caption
+    <video
+      src={src}
+      poster={poster}
+      muted={muted}
+      loop={loop}
+      controls
+      playsInline
+      preload="metadata"
+      className={cn("absolute inset-0 h-full w-full object-contain", className)}
+      onLoadedData={onLoad}
+      onError={onError}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+/**
+ * Unified video component for the Amplify frontend.
+ *
+ * Mirrors the `AmplifyImage` API:
+ * - Accepts either a `mediaId` (resolved via media-ingest proxy) or a direct `src`.
+ * - Accepts an optional `thumbnailId` / `thumbnailSrc` for the poster frame.
+ * - Three interaction modes: `"hover-play"`, `"click-play"` (default), `"controls"`.
+ * - Optional `lightbox` prop to open a fullscreen player portal.
+ *
+ * @example
+ * // Gallery card — hover to preview
+ * <AmplifyVideo mediaId={item.mediaId} mode="hover-play" />
+ *
+ * // Asset detail — click to play with fullscreen option
+ * <AmplifyVideo mediaId={asset.mediaId} mode="click-play" lightbox />
+ *
+ * // Canvas preview node — native controls
+ * <AmplifyVideo src={resolvedUrl} mode="controls" />
+ */
+export function AmplifyVideo({
+  mediaId,
+  src,
+  thumbnailId,
+  thumbnailSrc,
+  mode = "click-play",
+  lightbox = false,
+  muted,
+  loop = false,
+  className,
+  onLoad,
+  onError,
+}: AmplifyVideoProps) {
+  const resolvedSrc = src ?? (mediaId ? mediaApi.getMediaUrl(mediaId, "Original") : "");
+  const poster = buildPoster(thumbnailId, thumbnailSrc);
+
+  // Sensible muted default per mode
+  const effectiveMuted = muted ?? (mode === "hover-play" ? true : false);
+
+  if (!resolvedSrc) return null;
+
+  const sharedProps = {
+    src: resolvedSrc,
+    poster,
+    muted: effectiveMuted,
+    loop,
+    className,
+    onLoad,
+    onError,
+  };
+
+  if (mode === "hover-play") {
+    return <HoverPlayVideo {...sharedProps} lightbox={lightbox} />;
+  }
+
+  if (mode === "controls") {
+    return <ControlsVideo {...sharedProps} />;
+  }
+
+  // Default: "click-play"
+  return <ClickPlayVideo {...sharedProps} lightbox={lightbox} />;
+}

--- a/frontend/src/features/media/components/MediaCard.tsx
+++ b/frontend/src/features/media/components/MediaCard.tsx
@@ -5,6 +5,7 @@ import { Trash2, Film, AlertCircle, CheckCircle2, Expand } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { AmplifyImage } from "@/features/media/components/AmplifyImage";
+import { AmplifyVideo } from "@/features/media/components/AmplifyVideo";
 import type { UploadedMedia } from "@/features/media/useMediaUpload";
 
 interface MediaCardProps {
@@ -34,18 +35,10 @@ export function MediaCard({ media, onDelete, onOpen, className }: MediaCardProps
     >
       {/* Media preview */}
       {media.type === "video" ? (
-        <video
+        <AmplifyVideo
           src={media.url}
-          className="absolute inset-0 h-full w-full object-cover"
-          muted
-          playsInline
-          preload="metadata"
-          onMouseEnter={(e) => (e.currentTarget as HTMLVideoElement).play()}
-          onMouseLeave={(e) => {
-            const v = e.currentTarget as HTMLVideoElement;
-            v.pause();
-            v.currentTime = 0;
-          }}
+          mode="hover-play"
+          className="transition-transform duration-300 group-hover:scale-105"
         />
       ) : (
         <AmplifyImage

--- a/frontend/src/features/media/components/MediaLightbox.tsx
+++ b/frontend/src/features/media/components/MediaLightbox.tsx
@@ -663,6 +663,11 @@ function VideoEditor({ media }: { media: UploadedMedia }) {
     <div className="flex flex-col h-full">
       {/* ── Video stage ─────────────────────────────────────────────────────── */}
       <div className="flex-1 flex items-center justify-center p-6 relative min-h-0">
+        {/*
+         * Intentional raw <video> — this is a fully custom player with trim
+         * controls, time scrubbing, and play/pause overlay managed by this
+         * component. The functionality far exceeds AmplifyVideo's scope.
+         */}
         <video
           ref={videoRef}
           src={media.url}


### PR DESCRIPTION
## Problem

Closes #292

Multiple pages in the frontend contained their own ad-hoc `<video>` element with duplicated logic:

| Location | Duplicated logic |
|---|---|
| `MediaCard.tsx` | hover-play with manual `onMouseEnter/Leave` handlers |
| `assets/page.tsx` | hover-play with manual `onMouseEnter/Leave` handlers |
| `assets/[assetId]/page.tsx` | click-to-play with custom AnimatePresence overlay + ref management |
| `PreviewNode.tsx` (`VideoPreview`) | native controls with local URL resolution |

Each duplicates the hover/click logic, URL resolution, and play state. Any change (e.g. thumbnail support, format change, accessibility) must be applied in 4 different places.

## Solution

New component: `features/media/components/AmplifyVideo.tsx`

### API — mirrors `AmplifyImage`

```tsx
// Gallery card — hover to preview
<AmplifyVideo mediaId={item.mediaId} mode="hover-play" />

// Asset detail — click to play, click again for fullscreen
<AmplifyVideo src={asset.mediaUrl} mode="click-play" lightbox />

// Canvas preview node — native controls
<AmplifyVideo src={resolvedUrl} mode="controls" />
```

### Props

| Prop | Type | Description |
|---|---|---|
| `mediaId` | `string` | UUID — auto-resolved via `mediaApi.getMediaUrl()` |
| `src` | `string` | Direct URL (overrides `mediaId`) |
| `thumbnailId` | `string` | UUID for poster frame (Medium variant) |
| `thumbnailSrc` | `string` | Direct poster URL |
| `mode` | `'hover-play' \| 'click-play' \| 'controls'` | Interaction mode (default: `click-play`) |
| `lightbox` | `boolean` | Open fullscreen portal player on click |
| `muted` | `boolean` | Auto-true for `hover-play`, false otherwise |
| `loop` | `boolean` | Loop the video |

### Interaction modes

- **`hover-play`** — muted autoplay on `pointerenter`, pause+rewind on `pointerleave`. Passes `lightbox` prop through to open fullscreen instead of inline play.
- **`click-play`** — shows a Play button overlay. Clicking plays in place (or opens lightbox when `lightbox=true`).
- **`controls`** — native `<video controls>`.

### Lightbox (`VideoLightboxPortal`)
- Fullscreen portal overlay (fixed, z-200)
- Native video `controls` + a mute toggle button
- Closes on Escape or backdrop click
- Auto-plays on mount

## Migrations

All four call-sites are updated. Behaviour is equivalent to before — no functional regression.

- `MediaCard.tsx` → `<AmplifyVideo mode="hover-play" />`
- `assets/page.tsx` → `<AmplifyVideo mode="hover-play" />`
- `assets/[assetId]/page.tsx` → `<AmplifyVideo mode="click-play" lightbox />` (removes manual `videoRef`, `videoPlaying` state, AnimatePresence overlay)
- `PreviewNode.tsx` → `<AmplifyVideo mode="controls" />` (removes local `getMediaUrl` usage in `VideoPreview`)