### PR TITLE
fix(template-service): split ComfyUI engine into K8s sidecar container (#279)

### DIFF
--- a/template-service/Dockerfile
+++ b/template-service/Dockerfile
@@ -32,8 +32,8 @@ RUN poetry install --no-interaction --no-ansi --no-root --without dev
 # This layer invalidates often, but now the dependencies above it are cached!
 COPY . .
 
-# Make script executable
-RUN chmod +x scripts/entrypoint.sh
+# Make scripts executable
+RUN chmod +x scripts/entrypoint.sh scripts/entrypoint-api.sh scripts/entrypoint-engine.sh
 
 # Start
 ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/template-service/backend_template/engine/app/logger.py
+++ b/template-service/backend_template/engine/app/logger.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 _initialized = False
 
@@ -11,6 +10,6 @@ def setup_logger(log_level='INFO'):
 
     logger = logging.getLogger()
     logger.setLevel(log_level)
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(handler)

--- a/template-service/backend_template/engine/app/logger.py
+++ b/template-service/backend_template/engine/app/logger.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 _initialized = False
 
@@ -7,9 +8,9 @@ def setup_logger(log_level='INFO'):
     if _initialized:
         return
     _initialized = True
-    
+
     logger = logging.getLogger()
     logger.setLevel(log_level)
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(handler)

--- a/template-service/charts/envs/values.yaml
+++ b/template-service/charts/envs/values.yaml
@@ -21,6 +21,10 @@ service:
 
 resources: {}
 
+# Resource limits for the ComfyUI engine sidecar container
+engine:
+  resources: {}
+
 livenessProbe:
   httpGet:
     path: /health

--- a/template-service/charts/templates/deployment.yaml
+++ b/template-service/charts/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       annotations:
         instrumentation.opentelemetry.io/inject-python: "python-instrumentation"
+        instrumentation.opentelemetry.io/container-names: "{{ .Chart.Name }},engine"
       labels:
         {{- include "template-service.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/template-service/charts/templates/deployment.yaml
+++ b/template-service/charts/templates/deployment.yaml
@@ -21,9 +21,12 @@ spec:
     spec:
       serviceAccountName: {{ include "template-service.serviceAccountName" . }}
       containers:
+        # ── Main container: FastAPI gateway + DB migrations ───────────────────
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Use the API-only entrypoint (no engine); engine runs as a sidecar.
+          command: ["./scripts/entrypoint-api.sh"]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -59,6 +62,38 @@ spec:
               value: "{{ .Values.config.videoEditorUrl }}"
             - name: LANGFUSE_HOST
               value: "{{ .Values.config.langfuseUrl }}"
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secret.name }}
+          volumeMounts:
+            - name: sa-key
+              mountPath: /secrets
+              readOnly: true
+
+        # ── Sidecar: ComfyUI engine ───────────────────────────────────────────
+        # Shares the pod network namespace, so the API reaches it via
+        # http://localhost:8188 (engine_base_url default in config.py).
+        - name: engine
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["./scripts/entrypoint-engine.sh"]
+          ports:
+            - name: engine
+              containerPort: 8188
+              protocol: TCP
+          {{- with .Values.engine.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: PROJECT_ID
+              value: "{{ .Values.config.gcpProjectId }}"
+            - name: LOCATION
+              value: "{{ .Values.config.gcpLocation }}"
+            - name: STORAGE_URI
+              value: "{{ .Values.config.gcpStorageUri }}"
+            - name: SERVICE_ACCOUNT_KEY_FILE
+              value: "/secrets/sa-key.json"
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/template-service/charts/templates/deployment.yaml
+++ b/template-service/charts/templates/deployment.yaml
@@ -94,6 +94,14 @@ spec:
               value: "{{ .Values.config.gcpStorageUri }}"
             - name: SERVICE_ACCOUNT_KEY_FILE
               value: "/secrets/sa-key.json"
+            - name: USERSERVICE_URL
+              value: "{{ .Values.config.userServiceUrl }}"
+            - name: VIDEO_EDITOR_URL
+              value: "{{ .Values.config.videoEditorUrl }}"
+            - name: LANGFUSE_HOST
+              value: "{{ .Values.config.langfuseUrl }}"
+            - name: MEDIA_INGEST_URL
+              value: "{{ .Values.config.mediaIngestUrl }}"
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/template-service/scripts/entrypoint-api.sh
+++ b/template-service/scripts/entrypoint-api.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Entrypoint for the FastAPI gateway container only.
+# In Kubernetes this runs as the main container while the engine
+# runs as a sidecar (see charts/templates/deployment.yaml).
+# For local development, use entrypoint.sh which starts both processes.
+
+set -e
+
+# Run database migrations (only the API container should do this)
+echo "Running Database Migrations..."
+alembic upgrade head
+
+# Start FastAPI Gateway (foreground, public port 8000)
+echo "Starting FastAPI Gateway on port 8000..."
+exec uvicorn backend_template.web.app:app \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --root-path "${ROOT_PATH:-}" \
+    --forwarded-allow-ips="*"

--- a/template-service/scripts/entrypoint-engine.sh
+++ b/template-service/scripts/entrypoint-engine.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Entrypoint for the ComfyUI engine sidecar container.
+# In Kubernetes this runs alongside the FastAPI gateway in the same pod,
+# sharing the network namespace so the API can reach the engine via
+# http://localhost:8188 (see config.py: engine_base_url default).
+# For local development, the engine is started by entrypoint.sh instead.
+
+set -e
+
+echo "Starting ComfyUI Engine on port 8188..."
+exec python backend_template/engine/main.py


### PR DESCRIPTION
## Problem

Closes #279

`entrypoint.sh` was launching **two servers** in a single container:

```sh
python backend_template/engine/main.py &   # ComfyUI engine – background, no lifecycle mgmt
exec uvicorn ...                            # FastAPI – foreground
```

Issues with this approach:
- Engine crashes are **silent** — the main process stays alive, Kubernetes never restarts the pod, but requests to the engine fail.
- No way to set **independent resource limits** (engine is GPU/CPU heavy; API is lightweight).
- **Scaling** the API pod inadvertently scales engine instances too.
- Background `&` process is not a proper init — no signal forwarding, no zombie reaping.

## Fix: Kubernetes sidecar pattern

Both containers use the **same image** but with different entrypoints. They share the pod's network namespace, so `localhost:8188` still works — **zero config change required** (`engine_base_url` default in `config.py` is already `http://localhost:8188`).

```
Pod: template-service
├── container: template-service   → ./scripts/entrypoint-api.sh   (port 8000, runs migrations)
└── container: engine             → ./scripts/entrypoint-engine.sh (port 8188, ComfyUI)
```

Kubernetes now manages both containers independently:
- Engine crash → **pod restarts** (both containers), no silent degraded state.
- Resource limits can be set independently via `engine.resources` in `values.yaml`.

## Changes

| File | Change |
|---|---|
| `scripts/entrypoint-api.sh` | NEW — runs migrations + uvicorn only |
| `scripts/entrypoint-engine.sh` | NEW — runs ComfyUI engine only |
| `Dockerfile` | `chmod +x` for both new scripts |
| `charts/templates/deployment.yaml` | Main container uses `entrypoint-api.sh`; engine sidecar added |
| `charts/envs/values.yaml` | Adds `engine.resources: {}` key for future resource limits |

## Backward Compatibility

`entrypoint.sh` is **unchanged**. Docker Compose local dev (`api` service) continues to start both processes as before.

## Testing

1. Build the image — both new scripts should be present and executable.
2. Deploy to staging — verify both containers reach `Running` state.
3. Check FastAPI responds on `:8000/health`.
4. Check engine responds on `:8188` (exec into pod, `curl localhost:8188`).
5. Intentionally kill the engine container — verify the pod restarts.