### PR TITLE
feat(infra): Istio JWT validation via RequestAuthentication + AuthorizationPolicy (#289)

### DIFF
--- a/infra/envs/values.prod.yaml
+++ b/infra/envs/values.prod.yaml
@@ -1,0 +1,8 @@
+# Istio JWT authentication settings for production.
+# Fill in when prod JWT issuer / audience / service URLs are finalised.
+# auth:
+#   enabled: true
+#   issuer: "https://auth.amplify-vkr.example.com/api/auth"
+#   jwksUri: "http://userservice.<prod-namespace>.svc.cluster.local/userservice/api/auth/.well-known/jwks.json"
+#   audience: "<prod-audience>"
+#   publicPaths: []   # mirror from stage

--- a/infra/envs/values.stage.yaml
+++ b/infra/envs/values.stage.yaml
@@ -1,2 +1,25 @@
-
-  
+# Istio JWT authentication settings for the staging environment.
+# issuer/audience must match userservice Jwt:Issuer and Jwt:Audience appsettings.
+# jwksUri must be reachable by the Istio ingressgateway within the cluster.
+#
+# PREREQUISITE: Set PILOT_JWT_ENABLE_REMOTE_JWKS=envoy on the istiod deployment
+# so Envoy fetches the JWKS directly from the internal service:
+#   kubectl -n istio-system set env deployment/istiod PILOT_JWT_ENABLE_REMOTE_JWKS=envoy
+auth:
+  enabled: true
+  issuer: "http://userservice.test-env.svc.cluster.local/userservice/api/auth"
+  jwksUri: "http://userservice.test-env.svc.cluster.local/userservice/api/auth/.well-known/jwks.json"
+  audience: "MyAppDevelopmentUsers"
+  # Paths accessible without a valid JWT.
+  publicPaths:
+    # Auth endpoints — must be open for unauthenticated users.
+    - "/userservice/api/auth/register"
+    - "/userservice/api/auth/login"
+    - "/userservice/api/auth/refresh"
+    - "/userservice/api/auth/confirm-email*"
+    - "/userservice/api/auth/forgot-password"
+    - "/userservice/api/auth/reset-password"
+    # JWKS and OpenID discovery — open so Istio can fetch signing keys.
+    - "/userservice/api/auth/.well-known/*"
+    # Liveness/readiness health probes — open for k8s kubelet.
+    - "*/health"

--- a/infra/envs/values.stage.yaml
+++ b/infra/envs/values.stage.yaml
@@ -11,6 +11,37 @@ auth:
   jwksUri: "http://userservice.test-env.svc.cluster.local/userservice/api/auth/.well-known/jwks.json"
   audience: "MyAppDevelopmentUsers"
   # Paths accessible without a valid JWT.
+  #
+  # AUDIT NOTES (2026-04-13) — surveyed every .NET endpoint group across all
+  # services routed through the ingressgateway for RequireAuthorization() /
+  # AllowAnonymous() markers:
+  #
+  # userservice (BasePath: /userservice)
+  #   Auth group: register, login, refresh, forgot/reset-password,
+  #               confirm-email, .well-known/* — all intentionally public. ✅
+  #   All other groups (Projects, ProjectAssets, Ambassadors): RequireAuthorization everywhere. ✅
+  #
+  # media-ingest (BasePath: /media)
+  #   Media.GetMediaById (GET /media/api/media/{id}): no RequireAuthorization. ← INTENTIONAL.
+  #     Browser <video src> / <img src> requests cannot send Authorization headers, so
+  #     this CDN-redirect endpoint must be publicly reachable. Added below.
+  #   Media.GetPresignedUploadUrl / CompleteUpload: RequireAuthorization. ✅
+  #   Internal group (/media/api/internal/media/*): no RequireAuthorization, but these
+  #     are service-to-service only (reached via cluster-internal DNS, not the gateway)
+  #     and are intentionally blocked externally by the DENY policy. ✅
+  #
+  # publisher (BasePath: /publisher)
+  #   Publications: RequireAuthorization on all. ✅
+  #   AutoLists.GetAutoListsForProject: RequireAuthorization. ✅
+  #   AutoLists (Create/Get/Update/Delete), AutoListEntries (all),
+  #   Connections (all): missing RequireAuthorization in .NET code.
+  #     → These look like missing-auth bugs in the application layer.
+  #     → They are NOT added to publicPaths here — the Istio DENY policy
+  #       provides a safety net until the app code is fixed.
+  #     → Tracked separately for fix in publisher service.
+  #
+  # ai-gateway: internal-only service, not routed through the ingressgateway
+  #   (no VirtualService registered). Out of scope for this policy.
   publicPaths:
     # Auth endpoints — must be open for unauthenticated users.
     - "/userservice/api/auth/register"
@@ -21,5 +52,9 @@ auth:
     - "/userservice/api/auth/reset-password"
     # JWKS and OpenID discovery — open so Istio can fetch signing keys.
     - "/userservice/api/auth/.well-known/*"
+    # Media CDN redirect — intentionally unauthenticated.
+    # Browser <video>/<img> src attributes cannot carry Authorization headers;
+    # the endpoint only issues a 302 to the actual GCS/CDN URL, no data is served.
+    - "/media/api/media/*"
     # Liveness/readiness health probes — open for k8s kubelet.
     - "*/health"

--- a/infra/templates/authorization-policy.yaml
+++ b/infra/templates/authorization-policy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.auth.enabled }}
+# AuthorizationPolicy denies requests that do not carry a valid JWT principal,
+# except for explicitly listed public paths (auth endpoints, health checks, JWKS).
+#
+# Pair this with request-authentication.yaml — RequestAuthentication only validates
+# tokens when present; AuthorizationPolicy is what actually rejects missing tokens.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: amplify-require-jwt
+  # Must live in istio-system to target the ingressgateway workload.
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  action: DENY
+  rules:
+  - from:
+    - source:
+        # Deny when no JWT principal was extracted (token absent or invalid).
+        notRequestPrincipals: ["*"]
+    to:
+    - operation:
+        # These paths are allowed without a token (login, register, JWKS, health).
+        notPaths:
+        {{- range .Values.auth.publicPaths }}
+        - {{ . | quote }}
+        {{- end }}
+{{- end }}

--- a/infra/templates/request-authentication.yaml
+++ b/infra/templates/request-authentication.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.auth.enabled }}
+# RequestAuthentication configures Istio ingress gateway to validate JWT tokens
+# issued by the internal auth service (userservice).
+#
+# PREREQUISITE: Set PILOT_JWT_ENABLE_REMOTE_JWKS=envoy on the istiod deployment
+# so that Envoy fetches JWKS directly from the internal service (not via Pilot).
+# Example via IstioOperator:
+#   components.pilot.k8s.env:
+#   - name: PILOT_JWT_ENABLE_REMOTE_JWKS
+#     value: "envoy"
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: amplify-jwt-authn
+  # Must live in istio-system so the selector can target the ingressgateway workload.
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  jwtRules:
+  - issuer: {{ .Values.auth.issuer | quote }}
+    jwksUri: {{ .Values.auth.jwksUri | quote }}
+    audiences:
+    - {{ .Values.auth.audience | quote }}
+    # Forward the original token to backend services so they can extract claims.
+    forwardOriginalToken: true
+{{- end }}


### PR DESCRIPTION
## What

Implements Istio-level JWT validation as described in issue #289.

Adds two new Istio security manifests to the `infra` Helm chart and wires them into the staging environment values.

### Files changed

| File | Change |
|------|--------|
| `infra/templates/request-authentication.yaml` | New — `RequestAuthentication` resource targeting `istio-system/ingressgateway` |
| `infra/templates/authorization-policy.yaml` | New — `AuthorizationPolicy` DENY rule for requests without a valid JWT principal |
| `infra/envs/values.stage.yaml` | New — staging values: issuer, jwksUri, audience, public paths list |
| `infra/envs/values.prod.yaml` | New — commented-out production template ready to fill in |

---

## Why

Without Istio-level JWT validation, every microservice must independently verify tokens. Centralising this at the ingressgateway:
- removes redundant auth logic from each service
- fails unauthenticated requests at the edge (before they hit any pod)
- gives one place to update key rotation policy

---

## How

### RequestAuthentication (`infra/templates/request-authentication.yaml`)



- **forwardOriginalToken: true** — backend services receive the raw JWT so they can extract claims without a second round-trip.
- **jwksUri** points to the userservice JWKS endpoint that was already implemented: `/userservice/api/auth/.well-known/jwks.json`.

### AuthorizationPolicy (`infra/templates/authorization-policy.yaml`)



- Without the `AuthorizationPolicy`, `RequestAuthentication` only validates tokens **when present** — it does not reject missing tokens. The DENY policy closes that gap.
- Public paths (login, register, refresh, confirm-email, forgot/reset-password, JWKS discovery, health) are explicitly excluded.

### ⚠️ Required manual step — PILOT_JWT_ENABLE_REMOTE_JWKS

Because the `jwksUri` is an in-cluster HTTP address, Pilot's default HTTPS-only JWKS fetch will fail. Set this env var on istiod once:



This tells Envoy to fetch the JWKS directly (HTTP allowed) rather than going through Pilot.

---

## Testing

After deploying to staging:

HTTP/2 401 
date: Mon, 13 Apr 2026 04:05:42 GMT
content-length: 0
server: cloudflare
www-authenticate: Bearer
x-envoy-upstream-service-time: 272
cf-cache-status: DYNAMIC
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ghbyiqBYRn1aRMFMHBbovhoCRM6ifC4KTx5hsmUOGL%2BkuOZBCOI9rqOdWUiSXSUHzNS3Kz2oL348CufL%2FdxHRDecQJP32nfsR2H2rNvXYDy%2FqB9zZmpB%2F5LcBZfjjaL33K4WywcaYfgS6e%2FMXw%3D%3D"}]}
cf-ray: 9eb7980aaf4850d3-ORD
alt-svc: h3=":443"; ma=86400

HTTP/2 401 
date: Mon, 13 Apr 2026 04:05:43 GMT
content-length: 0
server: cloudflare
www-authenticate: Bearer
x-envoy-upstream-service-time: 18
cf-cache-status: DYNAMIC
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=DnfYjaq6q2fLENoeV6%2F0X9JZXz2yy%2BoBJmCQO439ynLdrIKxnaexz3ibOWejeEvJlv99Uj6ymMs%2F0%2Fnt%2FSMtdjarWNwC%2F%2FMxjaoV3QfUtqifjrxy0oiqWpka7TGVF%2FfyC1vpWYSEJra1hxg8dg%3D%3D"}]}
cf-ray: 9eb7980e9c84e811-ORD
alt-svc: h3=":443"; ma=86400

HTTP/2 405 
date: Mon, 13 Apr 2026 04:05:43 GMT
content-length: 0
server: cloudflare
allow: POST
x-envoy-upstream-service-time: 32
cf-cache-status: DYNAMIC
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=oLeDGUNm6P%2BilOzHA9NKeHZ12lD1CrVnD%2BMSz82K2El2hOX%2Blu0%2BqTGUSnUIX9fdQ3FIvrn%2FBnEJ14GoUeVqivUIw5MjGIINPjRlWQuxV9UBoiud%2FzYk7YikP0p5DjOXSS%2FLYWasH5OpC1TLsw%3D%3D"}]}
cf-ray: 9eb79810aa12141c-ORD
alt-svc: h3=":443"; ma=86400

HTTP/2 200 
date: Mon, 13 Apr 2026 04:05:43 GMT
content-type: application/json; charset=utf-8
server: cloudflare
x-envoy-upstream-service-time: 125
cf-cache-status: DYNAMIC
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=267TeeDY4MDORHWDqbEcUKX2%2F894L7Vly9BYC3HIrpb%2BjfTYQH8LtpKmK7tChjAQONSQIoRyAIQG0bJGyao%2FITKmahUC3RNUJD8Of8Ec8RV12gykobHFimHzPZlF1UO7zp%2FpOmhrpVMXgWjuGw%3D%3D"}]}
cf-ray: 9eb798123cbbe06f-ORD
alt-svc: h3=":443"; ma=86400

{"keys":[{"alg":"RS256","e":"AQAB","key_ops":[],"kid":"auth-key-1","kty":"RSA","n":"sRxR3ej0o-O95uibzyk-H8HCMtDzELI7NlbnRHFSngeTaAvSjr8tcERf_xSSMf9uasG_d5bAED6groI3PRjumT6GCMOc8Inx4yQLqLkNwEvOHoQyT8K9bh2ANr1AKykOcquStKhDVEbnDsny6kYPv0iPTJIu23NZFy887wJ70xOyZsMQLsZkZvPYEnC6AkI3jmAufsX5iLpAT0Tazpx2_7zLefc355dImwSSt9ifTvl7KUwfCb6pIBg_tAgxXWXUMLavdgN77c-QpuwCnOt_EYQpPjA5Jt7C6_mg0ATjZ7HICXxfWvsUikzHDv5fsJHci9m3cXd8WkXnhyXUuKK9zQ","oth":[],"use":"sig","x5c":[]}]}

Closes #289