### PR TITLE
fix(publisher): add RequireAuthorization to AutoLists, AutoListEntries, and Connections endpoints (#303)

### DIFF
--- a/publisher/src/Web/Endpoints/AutoListEntries.cs
+++ b/publisher/src/Web/Endpoints/AutoListEntries.cs
@@ -11,9 +11,9 @@ public class AutoListEntries : EndpointGroupBase
 
     public override void Map(RouteGroupBuilder groupBuilder)
     {
-        groupBuilder.MapPost(CreateAutoListEntry);
-        groupBuilder.MapPut(UpdateAutoListEntry, "{id}");
-        groupBuilder.MapDelete(DeleteAutoListEntry, "{id}");
+        groupBuilder.MapPost(CreateAutoListEntry).RequireAuthorization();
+        groupBuilder.MapPut(UpdateAutoListEntry, "{id}").RequireAuthorization();
+        groupBuilder.MapDelete(DeleteAutoListEntry, "{id}").RequireAuthorization();
     }
 
     public async Task<Created<Guid>> CreateAutoListEntry(ISender sender, CreateAutoListEntryCommand command)

--- a/publisher/src/Web/Endpoints/AutoLists.cs
+++ b/publisher/src/Web/Endpoints/AutoLists.cs
@@ -13,11 +13,11 @@ public class AutoLists : EndpointGroupBase
 
     public override void Map(RouteGroupBuilder groupBuilder)
     {
-        groupBuilder.MapPost(CreateAutoList);
-        groupBuilder.MapGet(GetAutoList, "{id}");
+        groupBuilder.MapPost(CreateAutoList).RequireAuthorization();
+        groupBuilder.MapGet(GetAutoList, "{id}").RequireAuthorization();
         groupBuilder.MapGet(GetAutoListsForProject).RequireAuthorization();
-        groupBuilder.MapPut(UpdateAutoList, "{id}");
-        groupBuilder.MapDelete(DeleteAutoList, "{id}");
+        groupBuilder.MapPut(UpdateAutoList, "{id}").RequireAuthorization();
+        groupBuilder.MapDelete(DeleteAutoList, "{id}").RequireAuthorization();
     }
 
     public async Task<Created<Guid>> CreateAutoList(ISender sender, CreateAutoListCommand command)

--- a/publisher/src/Web/Endpoints/Connections.cs
+++ b/publisher/src/Web/Endpoints/Connections.cs
@@ -14,11 +14,12 @@ public class Connections : EndpointGroupBase
 
     public override void Map(RouteGroupBuilder groupBuilder)
     {
-        groupBuilder.MapGet("{projectId}/auth-url", GetAuthUrl);
+        groupBuilder.MapGet("{projectId}/auth-url", GetAuthUrl).RequireAuthorization();
+        // OAuth callback: social platform redirects here without Authorization header — must stay public
         groupBuilder.MapPost(Connection);
 
-        groupBuilder.MapGet("{projectId}", GetProjectIntegrations);
-        groupBuilder.MapDelete("{projectId}/accounts/{accountId}", DisconnectAccount);
+        groupBuilder.MapGet("{projectId}", GetProjectIntegrations).RequireAuthorization();
+        groupBuilder.MapDelete("{projectId}/accounts/{accountId}", DisconnectAccount).RequireAuthorization();
     }
 
     public async Task<Ok<AuthUrlResponse>> GetAuthUrl(ISender sender, Guid projectId, SocialProvider provider)


### PR DESCRIPTION
## What

Adds missing `.RequireAuthorization()` to all unprotected endpoints in the Publisher service:

| File | Endpoint | Before | After |
|---|---|---|---|
| AutoLists.cs | POST / (Create) | ❌ Public | ✅ Protected |
| AutoLists.cs | GET /{id} (Get) | ❌ Public | ✅ Protected |
| AutoLists.cs | GET / (GetForProject) | ✅ Already OK | ✅ No change |
| AutoLists.cs | PUT /{id} (Update) | ❌ Public | ✅ Protected |
| AutoLists.cs | DELETE /{id} (Delete) | ❌ Public | ✅ Protected |
| AutoListEntries.cs | POST / (Create) | ❌ Public | ✅ Protected |
| AutoListEntries.cs | PUT /{id} (Update) | ❌ Public | ✅ Protected |
| AutoListEntries.cs | DELETE /{id} (Delete) | ❌ Public | ✅ Protected |
| Connections.cs | GET /{projectId}/auth-url | ❌ Public | ✅ Protected |
| Connections.cs | POST / (OAuth callback) | ❌ Public | ⚡ **Stays public** (see below) |
| Connections.cs | GET /{projectId} | ❌ Public | ✅ Protected |
| Connections.cs | DELETE /{projectId}/accounts/{accountId} | ❌ Public | ✅ Protected |

## Why

These endpoints were discovered during the Istio AuthorizationPolicy audit (PR #300). The Istio DENY policy was acting as an accidental safety net — without it, any unauthenticated caller could create/modify/delete AutoLists and Connections directly at the app layer.

## OAuth Callback Exception

`POST /api/connections` stays public intentionally:
- The social platform (Instagram, TikTok) redirects to this endpoint after user authorization
- Browser redirects do **not** forward `Authorization` headers
- The `state` parameter is a base64-encoded JSON blob containing only the provider type and project ID — no secrets
- A comment has been added to document this decision

## Risk

Low. This is purely additive — tightening security, no logic changes.

Closes #303