### PR TITLE
feat(userservice): refactor email sending to use DomainEvents (#58)

### DIFF
--- a/userservice/src/Application/Auth/EventHandlers/UserRegisteredEventHandler.cs
+++ b/userservice/src/Application/Auth/EventHandlers/UserRegisteredEventHandler.cs
@@ -1,0 +1,43 @@
+using System.Text;
+using Flurl;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using UserService.Application.Common.Interfaces;
+using UserService.Application.Common.Options;
+using UserService.Domain.Events.Auth;
+
+namespace UserService.Application.Auth.EventHandlers;
+
+public class UserRegisteredEventHandler(
+    IEmailService emailService,
+    IOptions<FrontendOptions> frontendOptions,
+    ILogger<UserRegisteredEventHandler> logger)
+    : INotificationHandler<UserRegisteredEvent>
+{
+    public async Task Handle(UserRegisteredEvent notification, CancellationToken cancellationToken)
+    {
+        var encodedToken = WebEncoders.Base64UrlEncode(
+            Encoding.UTF8.GetBytes(notification.RawConfirmationToken));
+
+        var options = frontendOptions.Value;
+        var callbackUrl = Url
+            .Combine(options.Url, options.EmailConfirmationPath)
+            .SetQueryParams(new { userId = notification.UserId, code = encodedToken });
+
+        try
+        {
+            await emailService.SendConfirmationLinkAsync(notification.Email, callbackUrl);
+        }
+        catch (Exception ex)
+        {
+            // Email delivery failures must not roll back the user record.
+            // The user can request a new confirmation link via the resend flow.
+            logger.LogError(
+                ex,
+                "Failed to send confirmation email to {Email} for user {UserId}",
+                notification.Email,
+                notification.UserId);
+        }
+    }
+}

--- a/userservice/src/Application/Auth/Register/RegisterUserCommand.cs
+++ b/userservice/src/Application/Auth/Register/RegisterUserCommand.cs
@@ -1,9 +1,5 @@
-using Flurl;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Options;
-using System.Text;
 using UserService.Application.Common.Interfaces;
-using UserService.Application.Common.Options;
+using UserService.Domain.Events.Auth;
 
 namespace UserService.Application.Auth.Register;
 
@@ -12,8 +8,7 @@ public record RegisterUserCommand(string Email, string Password) : IRequest<Guid
 public class RegisterUserCommandHandler(
     ITokenService tokenService,
     IIdentityService identityService,
-    IOptions<FrontendOptions> frontendOptions,
-    IEmailService emailService) : IRequestHandler<RegisterUserCommand, Guid>
+    IMediator mediator) : IRequestHandler<RegisterUserCommand, Guid>
 {
     public async Task<Guid> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
     {
@@ -27,15 +22,10 @@ public class RegisterUserCommandHandler(
 
         var rawToken = await tokenService.GenerateEmailConfirmationTokenAsync(userId);
 
-        var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken));
+        await mediator.Publish(
+            new UserRegisteredEvent(userId, request.Email, rawToken),
+            cancellationToken);
 
-        var baseFrontendUrl = frontendOptions.Value.Url;
-        var emailConfirmationPath = frontendOptions.Value.EmailConfirmationPath;
-
-        var callbackUrl = Url.Combine(baseFrontendUrl, emailConfirmationPath).SetQueryParams(new { userId, code = encodedToken });
-
-        await emailService.SendConfirmationLinkAsync(request.Email, callbackUrl);
         return userId;
     }
 }
-

--- a/userservice/src/Domain/Events/Auth/UserRegisteredEvent.cs
+++ b/userservice/src/Domain/Events/Auth/UserRegisteredEvent.cs
@@ -1,0 +1,20 @@
+namespace UserService.Domain.Events.Auth;
+
+public class UserRegisteredEvent : BaseEvent
+{
+    public Guid UserId { get; }
+    public string Email { get; }
+
+    /// <summary>
+    /// Raw (non-encoded) email confirmation token produced by ASP.NET Identity's UserManager.
+    /// The event handler is responsible for Base64Url-encoding before embedding in the link.
+    /// </summary>
+    public string RawConfirmationToken { get; }
+
+    public UserRegisteredEvent(Guid userId, string email, string rawConfirmationToken)
+    {
+        UserId = userId;
+        Email = email;
+        RawConfirmationToken = rawConfirmationToken;
+    }
+}

--- a/userservice/tests/Application.UnitTests/Auth/RegisterUserCommandHandlerTests.cs
+++ b/userservice/tests/Application.UnitTests/Auth/RegisterUserCommandHandlerTests.cs
@@ -1,6 +1,6 @@
-using Microsoft.Extensions.Options;
+using MediatR;
 using UserService.Application.Auth.Register;
-using UserService.Application.Common.Options;
+using UserService.Domain.Events.Auth;
 
 namespace UserService.Application.UnitTests.Auth;
 
@@ -9,8 +9,7 @@ public class RegisterUserCommandHandlerTests
 {
     private Mock<IIdentityService> _identityService = null!;
     private Mock<ITokenService> _tokenService = null!;
-    private Mock<IEmailService> _emailService = null!;
-    private Mock<IOptions<FrontendOptions>> _frontendOptions = null!;
+    private Mock<IMediator> _mediator = null!;
     private RegisterUserCommandHandler _handler = null!;
 
     [SetUp]
@@ -18,42 +17,41 @@ public class RegisterUserCommandHandlerTests
     {
         _identityService = new Mock<IIdentityService>();
         _tokenService = new Mock<ITokenService>();
-        _emailService = new Mock<IEmailService>();
-        _frontendOptions = new Mock<IOptions<FrontendOptions>>();
-
-        _frontendOptions.SetupGet(o => o.Value).Returns(new FrontendOptions
-        {
-            Url = "https://app.example.com",
-            EmailConfirmationPath = "/confirm",
-            EmailConfirmedPath = "/confirmed",
-            PasswordResetPath = "/reset"
-        });
+        _mediator = new Mock<IMediator>();
 
         _handler = new RegisterUserCommandHandler(
             _tokenService.Object,
             _identityService.Object,
-            _frontendOptions.Object,
-            _emailService.Object);
+            _mediator.Object);
     }
 
     [Test]
-    public async Task ReturnsUserIdAndSendsConfirmationEmail()
+    public async Task ReturnsUserIdAndPublishesUserRegisteredEvent()
     {
         var userId = Guid.NewGuid();
-        _identityService.Setup(s => s.CreateUserAsync("user@test.com", "Pass123!"))
+        const string email = "user@test.com";
+        const string rawToken = "raw-token";
+
+        _identityService.Setup(s => s.CreateUserAsync(email, "Pass123!"))
             .ReturnsAsync((Result.Success(), userId));
         _tokenService.Setup(s => s.GenerateEmailConfirmationTokenAsync(userId))
-            .ReturnsAsync("raw-token");
-        _emailService.Setup(s => s.SendConfirmationLinkAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(rawToken);
+        _mediator.Setup(m => m.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var result = await _handler.Handle(
-            new RegisterUserCommand("user@test.com", "Pass123!"),
+            new RegisterUserCommand(email, "Pass123!"),
             CancellationToken.None);
 
         result.ShouldBe(userId);
-        _emailService.Verify(
-            s => s.SendConfirmationLinkAsync("user@test.com", It.IsAny<string>()),
+
+        _mediator.Verify(
+            m => m.Publish(
+                It.Is<UserRegisteredEvent>(e =>
+                    e.UserId == userId &&
+                    e.Email == email &&
+                    e.RawConfirmationToken == rawToken),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -67,5 +65,24 @@ public class RegisterUserCommandHandlerTests
             await _handler.Handle(
                 new RegisterUserCommand("taken@test.com", "Pass123!"),
                 CancellationToken.None));
+    }
+
+    [Test]
+    public async Task DoesNotPublishEventWhenUserCreationFails()
+    {
+        _identityService.Setup(s => s.CreateUserAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((Result.Failure(["Email already taken"]), Guid.Empty));
+
+        try
+        {
+            await _handler.Handle(
+                new RegisterUserCommand("taken@test.com", "Pass123!"),
+                CancellationToken.None);
+        }
+        catch { /* expected */ }
+
+        _mediator.Verify(
+            m => m.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## What

Closes #58.

Decouples email delivery from `RegisterUserCommandHandler` by introducing a MediatR domain event (`UserRegisteredEvent`). The command now publishes the event; a dedicated event handler owns the email transport logic.

---

## Why

Currently `RegisterUserCommandHandler` directly calls `IEmailService.SendConfirmationLinkAsync`. This creates tight coupling between business logic (user registration) and infrastructure (email sending), and makes the registration flow fragile — a transient email failure would bubble up as a command error even though the user was successfully created.

Using DomainEvents mirrors the existing pattern (`ProjectCreatedEvent` → `ProjectCreatedEventHandler`) and is the first step toward an Outbox pattern if stricter delivery guarantees are needed later.

---

## How

### `Domain/Events/Auth/UserRegisteredEvent.cs` _(new)_

Carries three fields:
| Field | Purpose |
|---|---|
| `UserId` | Identity of the newly created user |
| `Email` | Delivery address for the confirmation link |
| `RawConfirmationToken` | Raw token from `UserManager` — handler Base64Url-encodes before embedding |

### `Application/Auth/EventHandlers/UserRegisteredEventHandler.cs` _(new)_

`INotificationHandler<UserRegisteredEvent>` that:
1. Base64Url-encodes the token (`WebEncoders.Base64UrlEncode`)
2. Builds the callback URL from `FrontendOptions` (same logic as before)
3. Calls `IEmailService.SendConfirmationLinkAsync`
4. **Catches and logs exceptions** — email failure must never roll back the user record; the user can request a new link via the resend flow

### `Application/Auth/Register/RegisterUserCommand.cs`

- Dropped: `IEmailService`, `IOptions<FrontendOptions>`
- Added: `IMediator`
- After user creation + token generation → `mediator.Publish(new UserRegisteredEvent(...))`

### `tests/Application.UnitTests/Auth/RegisterUserCommandHandlerTests.cs`

Updated to mock `IMediator` instead of `IEmailService`. Added:
- Assertion that `UserRegisteredEvent` is published with the exact `UserId`, `Email`, and `RawConfirmationToken`
- New test: event is **not** published when user creation fails

---

## Risks / Notes

- **No outbox** — fire-and-forget matches the existing codebase convention (`ProjectCreatedEventHandler`, `LibraryTemplateService`). Outbox can be layered on top later without changing the command.
- **Handler resilience** — email errors are caught so the user always gets a `userId` back from registration. This is strictly better than the current behaviour where a mail server blip would fail the whole request.
- The MediatR `Publish` call here is **in-process** (same request pipeline), not via RabbitMQ. Behaviour is synchronous within the request; no new infrastructure dependency is introduced.