### PR TITLE
AMPLIFY-290: Add structured output support to GeminiNode and LangfusePromptNode

### DIFF
--- a/template-service/backend_template/engine/comfy_api_nodes/apis/gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/apis/gemini.py
@@ -119,6 +119,8 @@ class GeminiGenerationConfig(BaseModel):
     temperature: float | None = Field(None, ge=0.0, le=2.0)
     topK: int | None = Field(None, ge=1)
     topP: float | None = Field(None, ge=0.0, le=1.0)
+    responseMimeType: str | None = Field(None, description="Set to 'application/json' to enable structured output.")
+    responseSchema: dict[str, Any] | None = Field(None, description="JSON Schema that the model output must conform to.")
 
 
 class GeminiImageOutputOptions(BaseModel):

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
@@ -3,6 +3,7 @@ API Nodes for Gemini Multimodal LLM Usage via Remote API
 See: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference
 """
 
+import json
 from enum import Enum
 from fnmatch import fnmatch
 from typing import Literal
@@ -14,6 +15,7 @@ from comfy_api_nodes.apis.gemini import (
     GeminiFileData,
     GeminiGenerateContentRequest,
     GeminiGenerateContentResponse,
+    GeminiGenerationConfig,
     GeminiImageConfig,
     GeminiImageGenerateContentRequest,
     GeminiImageGenerationConfig,
@@ -322,9 +324,31 @@ class GeminiNode(IO.ComfyNode):
                     optional=True,
                     tooltip="Optional video UUID to use as context for the model.",
                 ),
+                IO.String.Input(
+                    "response_schema",
+                    multiline=True,
+                    default="",
+                    optional=True,
+                    tooltip="Optional JSON Schema string. When provided, Gemini returns "
+                    "structured JSON matching this schema. The first array property "
+                    "found is extracted into the 'segments' list output.",
+                    advanced=True,
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=0,
+                    min=0,
+                    max=2**31 - 1,
+                    tooltip="Change this value to generate a new response. Not sent to the model.",
+                    control_after_generate=True,
+                ),
             ],
             outputs=[
                 IO.String.Output(display_name="text"),
+                IO.String.Output(
+                    display_name="segments",
+                    is_output_list=True,
+                ),
             ],
         )
 
@@ -336,6 +360,8 @@ class GeminiNode(IO.ComfyNode):
         system_prompt: str = "",
         images: IO.Autogrow.Type | None = None,
         video_uuid: str = "",
+        response_schema: str = "",
+        seed: int = 0,
     ) -> IO.NodeOutput:
         prompt = validate_string(prompt, strip_whitespace=True)
 
@@ -363,6 +389,16 @@ class GeminiNode(IO.ComfyNode):
         if system_prompt:
             gemini_system_prompt = GeminiSystemInstructionContent(parts=[GeminiTextPart(text=system_prompt)], role=None)
 
+        # Build generationConfig when structured output is requested
+        generation_config = None
+        response_schema = response_schema.strip() if response_schema else ""
+        if response_schema:
+            schema_dict = json.loads(response_schema)
+            generation_config = GeminiGenerationConfig(
+                responseMimeType="application/json",
+                responseSchema=schema_dict,
+            )
+
         token = get_vertex_ai_access_token()
         
         response = await sync_op(
@@ -379,13 +415,38 @@ class GeminiNode(IO.ComfyNode):
                         parts=parts,
                     )
                 ],
+                generationConfig=generation_config,
                 systemInstruction=gemini_system_prompt,
             ),
             response_model=GeminiGenerateContentResponse,
         )
 
         output_text = get_text_from_response(response) or "Empty response from Gemini model..."
-        return IO.NodeOutput(output_text, ui={"text": [output_text]})
+
+        # Parse structured output into segments list when schema was provided
+        segments: list[str] = []
+        if response_schema:
+            parsed = json.loads(output_text)
+            # Extract the first array property from the response
+            raw_items: list = []
+            if isinstance(parsed, list):
+                raw_items = parsed
+            elif isinstance(parsed, dict):
+                for value in parsed.values():
+                    if isinstance(value, list):
+                        raw_items = value
+                        break
+            # Each item can be a plain string or an object — grab the first string value
+            for item in raw_items:
+                if isinstance(item, str):
+                    segments.append(item.strip())
+                elif isinstance(item, dict):
+                    for v in item.values():
+                        if isinstance(v, str) and v.strip():
+                            segments.append(v.strip())
+                            break
+
+        return IO.NodeOutput(output_text, segments, ui={"text": [output_text]})
 
 class GeminiImageNode(IO.ComfyNode):
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_langfuse.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_langfuse.py
@@ -9,6 +9,7 @@ Also includes a generic StringInputNode for wiring literal string values
 """
 
 import asyncio
+import json
 import logging
 import re
 
@@ -124,6 +125,11 @@ class LangfusePromptNode(IO.ComfyNode):
             ],
             outputs=[
                 IO.String.Output(display_name="compiled_prompt"),
+                IO.String.Output(
+                    display_name="schema",
+                    tooltip="JSON schema extracted from the Langfuse prompt config, "
+                    "if present. Wire to GeminiNode response_schema for structured output.",
+                ),
             ],
         )
 
@@ -184,12 +190,29 @@ class LangfusePromptNode(IO.ComfyNode):
 
         compiled = prompt.compile(**compile_kwargs)
 
+        # Extract structured output schema from prompt config if present.
+        # Supports a flat "schema" key or OpenAI-style "response_format.json_schema.schema".
+        schema_str = ""
+        config = getattr(prompt, "config", None) or {}
+        if isinstance(config, dict):
+            schema_obj = config.get("schema")
+            if schema_obj is None:
+                # Try OpenAI-style nested path
+                rf = config.get("response_format", {})
+                if isinstance(rf, dict):
+                    js = rf.get("json_schema", {})
+                    if isinstance(js, dict):
+                        schema_obj = js.get("schema")
+            if schema_obj is not None:
+                schema_str = json.dumps(schema_obj)
+
         logger.info(
-            "[LangfusePromptNode] Compiled prompt (%d chars)",
+            "[LangfusePromptNode] Compiled prompt (%d chars), schema=%s",
             len(compiled),
+            "present" if schema_str else "absent",
         )
 
-        return IO.NodeOutput(compiled)
+        return IO.NodeOutput(compiled, schema_str)
 
 
 # ── Extension & Entry Point ───────────────────────────────────────────

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_text_utils.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_text_utils.py
@@ -1,0 +1,362 @@
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from comfy_api.latest import IO, ComfyExtension
+from typing_extensions import override
+
+logger = logging.getLogger(__name__)
+
+class TextSplitNode(IO.ComfyNode):
+    """
+    Splits a string by a delimiter into a list for downstream auto-batching.
+    Used for splitting generated scenes into individual segments.
+
+    Outputs:
+      segments — the split text items (auto-batched downstream)
+      indices  — parallel list [0, 1, 2, …] in lockstep with segments;
+                 wire to ShotIDNode.shot_index so each batch iteration
+                 receives the correct shot number automatically.
+      count    — scalar total number of segments
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TextSplitNode",
+            display_name="Text Split",
+            category="util",
+            description=(
+                "Split text by a delimiter. Outputs segments list for auto-batching, "
+                "a parallel indices list (0, 1, 2, …) for shot numbering, "
+                "and a scalar count."
+            ),
+            inputs=[
+                IO.String.Input(
+                    "text",
+                    force_input=True,
+                    tooltip="Text to split",
+                ),
+                IO.String.Input(
+                    "delimiter",
+                    default="*",
+                    tooltip="Split delimiter",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(
+                    display_name="segments",
+                    is_output_list=True,
+                    tooltip="Split text segments — auto-batched downstream.",
+                ),
+                IO.Int.Output(
+                    display_name="indices",
+                    is_output_list=True,
+                    tooltip="Zero-based index for each segment [0, 1, 2, …]. "
+                            "Wire to ShotIDNode.shot_index for automatic shot numbering.",
+                ),
+                IO.Int.Output(
+                    display_name="count",
+                    tooltip="Total number of segments produced.",
+                ),
+            ],
+        )
+
+    @classmethod
+    async def execute(cls, text: str, delimiter: str = "*") -> IO.NodeOutput:
+        logger.info("[TextSplitNode] Splitting text by %r", delimiter)
+        if not text:
+            segments = []
+        else:
+            segments = [s.strip() for s in text.split(delimiter) if s.strip()]
+
+        count = len(segments)
+        indices = list(range(count))
+        logger.info("[TextSplitNode] %d segments produced", count)
+
+        return IO.NodeOutput(segments, indices, count)
+
+class TextJoinNode(IO.ComfyNode):
+    """
+    Joins a list of strings into a single string for previewing list outputs.
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TextJoinNode",
+            display_name="Text Join",
+            category="util",
+            description="Join a list of text into a single string. Useful for previewing.",
+            is_input_list=True,
+            inputs=[
+                IO.String.Input(
+                    "texts", 
+                    force_input=True, 
+                    tooltip="List of texts to join"
+                ),
+                IO.String.Input(
+                    "separator", 
+                    default="\\n---\\n", 
+                    tooltip="String used to separate the joined texts"
+                ),
+            ],
+            outputs=[
+                IO.String.Output(
+                    display_name="joined_text"
+                ),
+            ],
+        )
+
+    @classmethod
+    async def execute(cls, texts: list[str], separator: list[str]) -> IO.NodeOutput:
+        sep = separator[0] if separator else "\n---\n"
+        sep_str = sep.replace("\\n", "\n")
+        joined = sep_str.join(texts)
+        return IO.NodeOutput(joined, ui={"text": [joined]})
+
+
+class DummyListNode(IO.ComfyNode):
+    """Outputs a hardcoded list of sample segments for testing ListSelectorNode."""
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="DummyListNode",
+            display_name="Dummy List (Test)",
+            category="util",
+            description="Outputs a hardcoded list of 4 sample scene segments for testing.",
+            is_output_node=True,
+            inputs=[],
+            outputs=[
+                IO.String.Output(
+                    display_name="segments",
+                    is_output_list=True,
+                ),
+            ],
+        )
+
+    @classmethod
+    async def execute(cls) -> IO.NodeOutput:
+        segments = [
+            "Hook: The new Model X redefines what a sports car can be. Bold. Fast. Uncompromising.",
+            "Problem: Most EVs sacrifice performance for range. You're stuck choosing between thrill and practicality.",
+            "Solution: Model X delivers 600 horsepower AND 400 miles of range. No compromise.",
+            "CTA: Visit your nearest dealer today. Test drive the future.",
+        ]
+        preview = "\n".join(f"[{i}] {s[:60]}..." for i, s in enumerate(segments))
+        logger.info("[DummyListNode] Emitting %d segments", len(segments))
+        return IO.NodeOutput(segments, ui={"text": [preview]})
+
+
+class ListSelectorNode(IO.ComfyNode):
+    """Pick one item from a list by index.
+
+    Receives the full segments list (is_input_list=True), extracts the
+    item at ``index``, and outputs it as a scalar string.  The canvas
+    preview shows the selected segment with its position, e.g. "[2/5]".
+
+    Wire one ListSelectorNode per scene branch, each set to a
+    different index, to route individual segments from a single
+    GeminiNode output into parallel generation branches.
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="ListSelectorNode",
+            display_name="List Selector",
+            category="util",
+            description=(
+                "Pick one item from a list by index. "
+                "Preview shows the selected segment with its position."
+            ),
+            is_input_list=True,
+            is_output_node=True,
+            inputs=[
+                IO.String.Input(
+                    "items",
+                    force_input=True,
+                    tooltip="List of items (e.g. segments from GeminiNode)",
+                ),
+                IO.Int.Input(
+                    "index",
+                    default=0,
+                    min=0,
+                    max=99,
+                    tooltip="Zero-based index of the item to select",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="selected"),
+            ],
+        )
+
+    @classmethod
+    async def execute(cls, items: list[str], index: list[int]) -> IO.NodeOutput:
+        idx = index[0] if index else 0
+        total = len(items)
+
+        if total == 0:
+            logger.warning("[ListSelectorNode] Empty list, returning empty string")
+            return IO.NodeOutput("", ui={"text": ["[0/0] (empty list)"]})
+
+        # Clamp to valid range
+        idx = max(0, min(idx, total - 1))
+        selected = items[idx]
+
+        preview = f"[{idx + 1}/{total}] {selected}"
+        logger.info("[ListSelectorNode] Selected index %d/%d", idx, total)
+
+        return IO.NodeOutput(selected, ui={"text": [preview]})
+
+
+class TextConcatNode(IO.ComfyNode):
+    """Concatenate multiple individually-wired strings into one.
+
+    Unlike TextJoinNode (which takes a list via is_input_list),
+    this node uses Autogrow inputs so you can wire outputs from
+    multiple ListSelectorNode instances into it — e.g. to merge
+    all base scene segments into a single context string for the
+    hook variation prompt.
+    """
+
+    @classmethod
+    def define_schema(cls):
+        autogrow_template = IO.Autogrow.TemplatePrefix(
+            input=IO.String.Input(
+                "text",
+                optional=True,
+                tooltip="A string to include in the concatenation",
+            ),
+            prefix="text",
+            min=1,
+            max=20,
+        )
+
+        return IO.Schema(
+            node_id="TextConcatNode",
+            display_name="Text Concat",
+            category="util",
+            description=(
+                "Concatenate multiple string inputs into one. "
+                "Wire base scene segments here to build context "
+                "for the hook variation prompt."
+            ),
+            is_output_node=True,
+            inputs=[
+                IO.Autogrow.Input(
+                    "texts",
+                    template=autogrow_template,
+                    optional=True,
+                    tooltip="Strings to concatenate (order matches slot order)",
+                ),
+                IO.String.Input(
+                    "separator",
+                    default="\\n\\n",
+                    tooltip="Separator between concatenated texts",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="merged_text"),
+            ],
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        texts: IO.Autogrow.Type | None = None,
+        separator: str = "\\n\\n",
+    ) -> IO.NodeOutput:
+        sep = separator.replace("\\n", "\n")
+
+        if not texts:
+            return IO.NodeOutput("", ui={"text": ["(no inputs)"]})
+
+        values = [v for v in texts.values() if v and v.strip()]
+        merged = sep.join(values)
+
+        preview = f"[{len(values)} parts merged]\n{merged[:500]}"
+        logger.info(
+            "[TextConcatNode] Merged %d inputs (%d chars)",
+            len(values),
+            len(merged),
+        )
+
+        return IO.NodeOutput(merged, ui={"text": [preview]})
+
+
+class ShotFilenameNode(IO.ComfyNode):
+    """Generate a structured filename prefix for SaveVideo.
+
+    Produces:  {template_code}_{scene:02d}_{shot:02d}_{run_id}
+    Example:   ugc-001_01_00_r20260415-1423
+
+    Wire TextSplitNode.indices (auto-batched) to shot_index so each
+    batch iteration receives the correct shot number automatically.
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="ShotFilenameNode",
+            display_name="Shot Filename",
+            category="util",
+            description=(
+                "Generate a structured filename prefix: "
+                "{template_code}_{scene:02d}_{shot:02d}_{run_id}. "
+                "Wire TextSplitNode.indices to shot_index for automatic shot numbering."
+            ),
+            inputs=[
+                IO.String.Input(
+                    "template_code",
+                    default="tpl-00000000",
+                    tooltip="Template slug+UUID8, e.g. 'ugc-001' or 'stk-a3f2c1d8'.",
+                ),
+                IO.Int.Input(
+                    "scene_index",
+                    default=1,
+                    min=1,
+                    max=99,
+                    tooltip="Scene number (1-based).",
+                ),
+                IO.Int.Input(
+                    "shot_index",
+                    default=0,
+                    min=0,
+                    max=99,
+                    force_input=True,
+                    tooltip="Shot index — wire from TextSplitNode.indices for auto-batching.",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(
+                    display_name="filename",
+                    tooltip="Filename prefix ready for SaveVideo.",
+                ),
+            ],
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        template_code: str,
+        scene_index: int = 1,
+        shot_index: int = 0,
+    ) -> IO.NodeOutput:
+        slug = re.sub(r"[^\w\-]", "-", template_code.strip()).strip("-") or "tpl"
+        run_id = datetime.now(timezone.utc).strftime("r%Y%m%d-%H%M")
+        filename = f"{slug}_{scene_index:02d}_{shot_index:02d}_{run_id}"
+        logger.info("[ShotFilenameNode] %s", filename)
+        return IO.NodeOutput(filename, ui={"text": [filename]})
+
+
+class TextUtilsExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[IO.ComfyNode]]:
+        return [TextSplitNode, TextJoinNode, DummyListNode, ListSelectorNode, TextConcatNode, ShotFilenameNode]
+
+async def comfy_entrypoint() -> TextUtilsExtension:
+    return TextUtilsExtension()
+

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_veo2.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_veo2.py
@@ -30,6 +30,7 @@ MODELS_MAP = {
     "veo-3.1-fast-generate": "veo-3.1-fast-generate-001",
     "veo-3.0-generate-001": "veo-3.0-generate-001",
     "veo-3.0-fast-generate-001": "veo-3.0-fast-generate-001",
+    "veo-3.1-lite-generate-001": "veo-3.1-lite-generate-001",
 }
 
 GEMINI_BASE_ENDPOINT = f"https://aiplatform.googleapis.com/v1/projects/{gemini_config.project_id}/locations/{gemini_config.location}/publishers/google/models"
@@ -420,8 +421,8 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=["veo-3.1-generate", "veo-3.1-fast-generate"],
-                    default="veo-3.1-fast-generate",
+                    options=["veo-3.1-generate", "veo-3.1-fast-generate", "veo-3.1-lite-generate-001"],
+                    default="veo-3.1-lite-generate-001",
                 ),
                 IO.Boolean.Input(
                     "generate_audio",
@@ -445,7 +446,7 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
         seed: int,
         first_frame_uuid: str | None = None,
         last_frame_uuid: str | None = None,
-        model: str = "veo-3.1-fast-generate",
+        model: str = "veo-3.1-lite-generate-001",
         generate_audio: bool = True,
     ):
         model = MODELS_MAP[model]

--- a/template-service/backend_template/engine/config.py
+++ b/template-service/backend_template/engine/config.py
@@ -1,7 +1,10 @@
+import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+ENV_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+
 class ConfigBase(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(env_file=ENV_PATH, env_file_encoding="utf-8", extra="ignore")
 
 class GeminiConfig(ConfigBase):
     service_account_key_file: str
@@ -13,7 +16,7 @@ class MediaIngestConfig(ConfigBase):
     media_ingest_url: str = "http://localhost:5070/media/api"
 
 class EngineConfig(ConfigBase):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore", env_prefix="ENGINE_")
+    model_config = SettingsConfigDict(env_file=ENV_PATH, env_file_encoding="utf-8", extra="ignore", env_prefix="ENGINE_")
     listen: str = "127.0.0.1"
     port: int = 8188
     verbose: bool = True              


### PR DESCRIPTION
## Summary

Extends GeminiNode and LangfusePromptNode to support Gemini's structured JSON output (`responseSchema`), enabling schema-enforced script segmentation in the dynamic video workflow. This replaces the fragile delimiter-based approach (Gemini inserts `*` → TextSplitNode splits) with deterministic JSON parsing.

## Changes

### `apis/gemini.py`
- Added `responseMimeType` and `responseSchema` fields to `GeminiGenerationConfig`

### `nodes_gemini.py`
- Added optional `response_schema` input (advanced, JSON string) to `GeminiNode`
- Added `segments` list output (`is_output_list=True`) for auto-batching downstream
- When schema is provided: sets `generationConfig` on API request, parses JSON response into segment strings
- Backward compatible — without schema, node behaves exactly as before

### `nodes_langfuse.py`
- Added `schema` output to `LangfusePromptNode` that extracts JSON schema from `prompt.config`
- Supports flat `config.schema` key and OpenAI-style `config.response_format.json_schema.schema` path
- Schema is version-controlled alongside the prompt in Langfuse — no manual copy-paste needed

### `config.py`
- Fixed `.env` file resolution to use absolute path based on `__file__` location
- Ensures config loads correctly regardless of working directory (important for ComfyUI portable)

Closes #290