### PR TITLE
fix(ci): redeploy only services changed in the last commit (#310)

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -18,9 +18,17 @@ jobs:
             ai-gateway: ${{ steps.filter.outputs.ai-gateway }}
         steps:
             - uses: actions/checkout@v4
+              with:
+                  # fetch-depth: 2 is required for HEAD^1 comparison on synchronize events
+                  fetch-depth: 2
             - uses: dorny/paths-filter@v3
               id: filter
               with:
+                  # On 'synchronize' (new commit pushed) compare only the last commit so that
+                  # only services touched by that commit are re-deployed, not the entire PR diff.
+                  # On 'opened'/'reopened' compare against the base branch to catch everything
+                  # that needs an initial deploy.
+                  base: ${{ github.event.action == 'synchronize' && 'HEAD^1' || github.base_ref }}
                   filters: |
                       userservice:
                         - 'userservice/**'


### PR DESCRIPTION
## Problem

Closes #310

`dorny/paths-filter` was comparing the **full PR diff** against the base branch on every `synchronize` event. This means pushing a single commit that only touches `userservice/` would still trigger redeploys of every other service that was modified anywhere in the PR. Expensive and slow.

## Root cause

`dorny/paths-filter` defaults `base` to `github.base_ref` for `pull_request` events — the full diff from PR open to now, not just the last push.

## Fix

```yaml
base: ${{ github.event.action == 'synchronize' && 'HEAD^1' || github.base_ref }}
```

| Event | `base` | Behaviour |
|---|---|---|
| `opened` / `reopened` | `github.base_ref` | Full PR diff — deploys everything in the PR on first run |
| `synchronize` | `HEAD^1` | Last commit diff only — skip unchanged services |

Also adds `fetch-depth: 2` to `actions/checkout` (required for `HEAD^1` to be reachable in the shallow clone).

## What changes

Single file: `.github/workflows/deploy-pr.yaml` — 8 lines added (comments + two config keys).

## Result

Same behaviour as Netlify: if the last commit didn't touch a service, its deploy job is skipped with a green ✅ and no build time consumed.