### PR TITLE
[VideoEditor] Expose endpoints to ingress (#321)

### DIFF
--- a/video-editor/charts/envs/values.yaml
+++ b/video-editor/charts/envs/values.yaml
@@ -67,3 +67,23 @@ secrets:
     key: ""
   s3SecretKey:
     key: ""
+
+virtualService:
+  name: video-editor-vs
+  hosts: []
+  http:
+    timeout: 30s
+    retries:
+      attempts: 3
+      perTryTimeout: 10s
+      retryOn: gateway-error,connect-failure,refused-stream,5xx
+
+gateway:
+  name: amplify-gateway
+
+cors:
+  allowedOrigins: []
+  allowedOriginsRegex: []
+
+config:
+  rootPath: "/video-editor"

--- a/video-editor/charts/envs/values.yaml.gotmpl
+++ b/video-editor/charts/envs/values.yaml.gotmpl
@@ -1,2 +1,18 @@
 image:
   tag: {{ env "VIDEO_EDITOR_IMAGE_TAG" | default "latest" }}
+
+gateway:
+  name: {{ .Values.global.gateway.name }}
+
+virtualService:
+  hosts:
+    - {{ .Values.global.appDomain }}
+    - {{ .Values.global.clusterDomain }}
+
+cors:
+  allowedOrigins:
+    - "https://{{ .Values.global.appDomain }}"
+    - "http://localhost:3000"
+    - "https://localhost:3000"
+  allowedOriginsRegex:
+    - "https://.*--amplify-testing\\.netlify\\.app"

--- a/video-editor/charts/templates/deployment.yaml
+++ b/video-editor/charts/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: "{{ .Values.minio.location }}"
             - name: MEDIA_INGEST_URL
               value: "{{ .Values.internalServices.mediaIngest.url }}"
+            - name: ROOT_PATH
+              value: "{{ .Values.config.rootPath }}"
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/video-editor/charts/templates/virtualservice.yaml
+++ b/video-editor/charts/templates/virtualservice.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ .Values.virtualService.name }}
+spec:
+  hosts:
+  {{- range .Values.virtualService.hosts }}
+  - {{ . | quote }}
+  {{- end }}
+  # internal service communication
+  - "{{ include "video-editor.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+  gateways:
+  - {{ .Values.gateway.name }}
+  http:
+  - match:
+    - uri:
+        prefix: "/video-editor/"
+    rewrite:
+      uri: "/"
+    corsPolicy:
+      allowOrigins:
+      {{- range .Values.cors.allowedOrigins }}
+      - exact: {{ . | quote }}
+      {{- end }}
+      {{- range .Values.cors.allowedOriginsRegex }}
+      - regex: {{ . | quote }}
+      {{- end }}
+      allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+      allowHeaders: ["*"]
+      allowCredentials: true
+      maxAge: "24h"
+    route:
+    - destination:
+        host: "{{ include "video-editor.fullname" . }}"
+        port:
+          number: {{ .Values.service.port }}
+    timeout: {{ .Values.virtualService.http.timeout }}
+    retries:
+      attempts: {{ .Values.virtualService.http.retries.attempts }}
+      perTryTimeout: {{ .Values.virtualService.http.retries.perTryTimeout }}
+      retryOn: {{ .Values.virtualService.http.retries.retryOn }}

--- a/video-editor/main.py
+++ b/video-editor/main.py
@@ -71,4 +71,5 @@ def run_rabbitmq():
 rabbitmq_thread = threading.Thread(target=run_rabbitmq, daemon=True)
 rabbitmq_thread.start()
 
-uvicorn.run("api:api", host="0.0.0.0", port=8000)
+root_path = os.getenv("ROOT_PATH", "")
+uvicorn.run("api:api", host="0.0.0.0", port=8000, root_path=root_path, forwarded_allow_ips="*")


### PR DESCRIPTION
## What

Exposes the `video-editor` FastAPI service through the Istio ingress gateway under the `/video-editor/` prefix.

## Why

Issue #321 — the service was deployed but unreachable externally. To serve external traffic it needs a VirtualService pointing the ingress gateway to the service.

## How

- **`virtualservice.yaml`** — new Istio VirtualService that matches `prefix: /video-editor/` and rewrites to `/` before forwarding to the service. CORS policy mirrors other services in the cluster.
- **`values.yaml`** — added `virtualService`, `gateway`, `cors`, and `config.rootPath` default values.
- **`values.yaml.gotmpl`** — populated gateway name, VS hosts (`appDomain` + `clusterDomain`), and CORS origins from global Helm values (same pattern as `template-service`).
- **`deployment.yaml`** — injects `ROOT_PATH` env var into the API container.
- **`main.py`** — passes `root_path` and `forwarded_allow_ips="*"` to uvicorn so FastAPI generates correct OpenAPI docs URLs behind the proxy.

## Checklist

- [x] VirtualService follows existing pattern (template-service, media-ingest)
- [x] No changes to application routes — prefix is stripped by Istio rewrite
- [x] `ROOT_PATH` is injected via Helm so local dev keeps working without it
- [x] CORS config driven from global values

Closes #321