### PR TITLE
fix(video-editor): correct temp_audiofile_path param in AddMusicStep

### DIFF
--- a/video-editor/editors/base_ugc/steps/add_music.py
+++ b/video-editor/editors/base_ugc/steps/add_music.py
@@ -31,10 +31,10 @@ class AddMusicStep(PipelineStep):
 
         final = video.with_audio(mixed_audio)
         final.write_videofile(
-            output_path, 
-            codec="libx264", 
-            audio_codec="aac", 
-            temp_audio_file = ctx.workspace.get_temp_path("mp3"),
+            output_path,
+            codec="libx264",
+            audio_codec="aac",
+            temp_audiofile_path=ctx.workspace.get_temp_path("mp3"),
             logger=None)
 
         video.close()


### PR DESCRIPTION
## What

`AddMusicStep.execute()` was calling `write_videofile` with `temp_audio_file=...` — a parameter name that moviepy does not recognise and silently ignores.

All other pipeline steps (`concatenate`, `remove_silence`, `add_captions`, `generate_voiceover`) already use the correct name `temp_audiofile_path`.

## Why it matters

Because the parameter was silently ignored, moviepy fell back to the system default temp directory (`/tmp`) for the intermediate audio file. This means:

- **Disk exhaustion** — the temp file is never cleaned up by `workspace.cleanup()`, and under concurrent jobs they accumulate.
- **Name collisions** — in containerised environments sharing `/tmp`, concurrent runs can step on each other.

## Change

```diff
- temp_audio_file = ctx.workspace.get_temp_path("mp3"),
+ temp_audiofile_path=ctx.workspace.get_temp_path("mp3"),
```

One-line typo fix. No logic change.

## Testing

Verified all five `write_videofile` call-sites in `editors/base_ugc/steps/` now consistently use `temp_audiofile_path`.

Closes #315