### PR TITLE
AMPLIFY-330: Resilient Veo pipeline and BatchUGCEditingNode

### DIFF
--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_gemini.py
@@ -43,6 +43,34 @@ from comfy_api_nodes.util import get_vertex_ai_access_token, fetch_media_uri_fro
 
 GEMINI_BASE_ENDPOINT = f"https://aiplatform.googleapis.com/v1/projects/{gemini_config.project_id}/locations/{gemini_config.location}/publishers/google/models"
 
+# ---------------------------------------------------------------------------
+# Pacing zone table — empirically calibrated from avatar video experiments.
+# Green: target zone. Yellow: acceptable. Outside yellow: red (avoid).
+# ---------------------------------------------------------------------------
+PACING_ZONES: dict[int, dict[str, tuple[int, int]]] = {
+    4: {"green": (70, 80),   "yellow": (65, 85)},
+    6: {"green": (105, 120), "yellow": (98, 128)},
+    8: {"green": (140, 160), "yellow": (130, 170)},
+}
+
+
+def best_duration_for_chars(char_count: int) -> int:
+    """
+    Given a segment's character count, return the video duration (4, 6, or 8 s)
+    whose pacing zone best fits it.
+
+    Priority: green zone first, then yellow, then longest available (8 s).
+    """
+    for dur in [4, 6, 8]:
+        lo, hi = PACING_ZONES[dur]["green"]
+        if lo <= char_count <= hi:
+            return dur
+    for dur in [4, 6, 8]:
+        lo, hi = PACING_ZONES[dur]["yellow"]
+        if lo <= char_count <= hi:
+            return dur
+    return 8  # fallback: give the avatar as much time as possible
+
 
 class GeminiModel(str, Enum):
     """
@@ -373,6 +401,10 @@ class GeminiNode(IO.ComfyNode):
                     display_name="segments",
                     is_output_list=True,
                 ),
+                IO.Int.Output(
+                    display_name="duration_seconds",
+                    is_output_list=True,
+                ),
             ],
         )
 
@@ -447,8 +479,15 @@ class GeminiNode(IO.ComfyNode):
 
         output_text = get_text_from_response(response) or "Empty response from Gemini model..."
 
-        # Parse structured output into segments list when schema was provided
+        # Parse structured output into segments and duration_seconds when schema was provided.
+        # Handles three schema shapes:
+        #   1. No schema                          → both lists empty.
+        #   2. {script_segment}                   → segments populated; duration derived via
+        #                                            Python char-count post-processing.
+        #   3. {script_segment, duration_seconds} → same — LLM-suggested duration is ignored;
+        #                                            Python char count always wins for accuracy.
         segments: list[str] = []
+        duration_seconds: list[int] = []
         if response_schema:
             parsed = json.loads(output_text)
             # Extract the first array property from the response
@@ -460,17 +499,57 @@ class GeminiNode(IO.ComfyNode):
                     if isinstance(value, list):
                         raw_items = value
                         break
-            # Each item can be a plain string or an object — grab the first string value
             for item in raw_items:
                 if isinstance(item, str):
-                    segments.append(item.strip())
+                    # Plain-string schema
+                    seg = item.strip()
+                    segments.append(seg)
+                    duration_seconds.append(best_duration_for_chars(len(seg)))
                 elif isinstance(item, dict):
-                    for v in item.values():
-                        if isinstance(v, str) and v.strip():
-                            segments.append(v.strip())
-                            break
+                    if "script_segment" in item:
+                        seg = item["script_segment"].strip()
+                        segments.append(seg)
+                        if "duration_seconds" in item:
+                            # Trust Gemini's duration choice — it has full segment context.
+                            # best_duration_for_chars is only a fallback for schemas without
+                            # a duration field, not an override of an explicit model decision.
+                            try:
+                                dur = int(item["duration_seconds"])
+                                if dur not in (4, 6, 8):
+                                    dur = best_duration_for_chars(len(seg))
+                            except (ValueError, TypeError):
+                                dur = best_duration_for_chars(len(seg))
+                            duration_seconds.append(dur)
+                        else:
+                            # script_segment-only schema — compute duration from char count.
+                            duration_seconds.append(best_duration_for_chars(len(seg)))
+                    else:
+                        # Unknown schema shape — grab the first non-empty string value.
+                        for v in item.values():
+                            if isinstance(v, str) and v.strip():
+                                seg = v.strip()
+                                segments.append(seg)
+                                duration_seconds.append(best_duration_for_chars(len(seg)))
+                                break
 
-        return IO.NodeOutput(output_text, segments, ui={"text": [output_text]})
+        # Safety net: model returned an empty segments array despite a non-empty transcript.
+        # This happens when the input is shorter than the minimum yellow zone (65 chars for 4 s)
+        # and the model treats it as "no valid segments". Fall back to a single segment so
+        # downstream nodes always receive at least one item.
+        # Duration is hardcoded to 4 — this branch only fires for very short transcripts,
+        # so the shortest clip is the only sensible choice. (best_duration_for_chars would
+        # incorrectly return 8 as its out-of-zone fallback here.)
+        if response_schema and not segments and output_text.strip():
+            seg = output_text.strip()
+            # logger.warning(
+            #     "[GeminiNode] Model returned empty segments for a %d-char transcript. "
+            #     "Falling back to a single 4-second segment.",
+            #     len(seg),
+            # )
+            segments = [seg]
+            duration_seconds = [4]
+
+        return IO.NodeOutput(output_text, segments, duration_seconds, ui={"text": [output_text]})
 
 class GeminiImageNode(IO.ComfyNode):
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_text_utils.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_text_utils.py
@@ -79,7 +79,9 @@ class TextSplitNode(IO.ComfyNode):
 
 class TextJoinNode(IO.ComfyNode):
     """
-    Joins a list of strings into a single string for previewing list outputs.
+    Joins a list of strings or integers into a single string for previewing list outputs.
+    Both inputs are optional — connect whichever list you want to inspect.
+    If both are connected, integers are appended after texts.
     """
 
     @classmethod
@@ -88,18 +90,28 @@ class TextJoinNode(IO.ComfyNode):
             node_id="TextJoinNode",
             display_name="Text Join",
             category="util",
-            description="Join a list of text into a single string. Useful for previewing.",
+            description=(
+                "Join a list of strings or integers into a single string for previewing. "
+                "Connect a string list, an integer list, or both."
+            ),
             is_input_list=True,
             inputs=[
                 IO.String.Input(
-                    "texts", 
-                    force_input=True, 
-                    tooltip="List of texts to join"
+                    "texts",
+                    force_input=True,
+                    optional=True,
+                    tooltip="Optional list of strings to join (e.g. segments from GeminiNode)",
+                ),
+                IO.Int.Input(
+                    "integers",
+                    force_input=True,
+                    optional=True,
+                    tooltip="Optional list of integers to join (e.g. duration_seconds from GeminiNode)",
                 ),
                 IO.String.Input(
-                    "separator", 
-                    default="\\n---\\n", 
-                    tooltip="String used to separate the joined texts"
+                    "separator",
+                    default="\\n---\\n",
+                    tooltip="String used to separate the joined items",
                 ),
             ],
             outputs=[
@@ -110,10 +122,22 @@ class TextJoinNode(IO.ComfyNode):
         )
 
     @classmethod
-    async def execute(cls, texts: list[str], separator: list[str]) -> IO.NodeOutput:
+    async def execute(
+        cls,
+        separator: list[str],
+        texts: list[str] | None = None,
+        integers: list[int] | None = None,
+    ) -> IO.NodeOutput:
         sep = separator[0] if separator else "\n---\n"
         sep_str = sep.replace("\\n", "\n")
-        joined = sep_str.join(texts)
+
+        items: list[str] = []
+        if texts:
+            items.extend(str(t) for t in texts)
+        if integers:
+            items.extend(str(i) for i in integers)
+
+        joined = sep_str.join(items) if items else "(no input connected)"
         return IO.NodeOutput(joined, ui={"text": [joined]})
 
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_veo2.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_veo2.py
@@ -1,5 +1,6 @@
 import base64
 import asyncio
+import logging
 
 from comfy_api.latest import IO, ComfyExtension
 from typing_extensions import override
@@ -16,6 +17,8 @@ from comfy_api_nodes.util import (
     ApiEndpoint,
     poll_op,
     sync_op,
+    RAIFilteredError,
+    VeoTransientError,
 )
 
 from comfy_api_nodes.util import get_vertex_ai_access_token, fetch_media_uri_from_ingest, register_media_uri_with_ingest
@@ -34,6 +37,14 @@ MODELS_MAP = {
 }
 
 GEMINI_BASE_ENDPOINT = f"https://aiplatform.googleapis.com/v1/projects/{gemini_config.project_id}/locations/{gemini_config.location}/publishers/google/models"
+
+_RAI_MAX_ATTEMPTS = 3
+_RAI_RETRY_BASE_DELAY = 5.0        # delays: 5s, 10s
+
+_TRANSIENT_MAX_ATTEMPTS = 5
+_TRANSIENT_RETRY_BASE_DELAY = 30.0  # delays: 30s, 60s, 120s, 240s
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -436,33 +447,28 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
         )
 
     @classmethod
-    async def execute(
+    async def _run_veo_generation(
         cls,
+        *,
+        model: str,
         prompt: str,
         negative_prompt: str,
         resolution: str,
         aspect_ratio: str,
         duration: int,
         seed: int,
-        first_frame_uuid: str | None = None,
-        last_frame_uuid: str | None = None,
-        model: str = "veo-3.1-lite-generate-001",
-        generate_audio: bool = True,
-    ):
-        model = MODELS_MAP[model]
+        generate_audio: bool,
+        first_frame_uri: str | None,
+        last_frame_uri: str | None,
+        attempt: int,
+    ) -> str:
+        """
+        Submit one Veo generation request and wait for completion.
 
-        first_frame_task = (
-            asyncio.create_task(fetch_media_uri_from_ingest(cls, first_frame_uuid))
-            if first_frame_uuid else None
-        )
-        last_frame_task = (
-            asyncio.create_task(fetch_media_uri_from_ingest(cls, last_frame_uuid))
-            if last_frame_uuid else None
-        )
-
-        first_frame_uri = await first_frame_task if first_frame_task else None
-        last_frame_uri = await last_frame_task if last_frame_task else None
-
+        Returns the registered MediaIngest media_id on success.
+        Raises RAIFilteredError when the generated video is blocked by RAI filters.
+        All other failures propagate as-is.
+        """
         initial_response = await sync_op(
             cls,
             ApiEndpoint(
@@ -487,20 +493,21 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
                     aspectRatio=aspect_ratio,
                     personGeneration="ALLOW",
                     durationSeconds=duration,
-                    enhancePrompt=True,  # cannot be False for Veo3
+                    enhancePrompt=True,
                     seed=seed,
                     generateAudio=generate_audio,
                     negativePrompt=negative_prompt,
                     resolution=resolution,
-                    storageUri=gemini_config.storage_uri
+                    storageUri=gemini_config.storage_uri,
                 ),
             ),
         )
+
         poll_response = await poll_op(
             cls,
-            ApiEndpoint(    
-                path=f"{GEMINI_BASE_ENDPOINT}/{model}:fetchPredictOperation", 
-                method="POST", 
+            ApiEndpoint(
+                path=f"{GEMINI_BASE_ENDPOINT}/{model}:fetchPredictOperation",
+                method="POST",
                 headers={"Authorization": f"Bearer {get_vertex_ai_access_token()}"}
             ),
             response_model=VeoGenVidPollResponse,
@@ -513,25 +520,126 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
         )
 
         if poll_response.error:
-            raise Exception(f"Veo API error: {poll_response.error.message} (code: {poll_response.error.code})")
+            code = poll_response.error.code
+            message = poll_response.error.message
+            if code in VeoTransientError.RETRYABLE_CODES:
+                raise VeoTransientError(message=message, code=code)
+            raise Exception(f"Veo API error: {message} (code: {code})")
 
         response = poll_response.response
         filtered_count = response.raiMediaFilteredCount
         if filtered_count:
             reasons = response.raiMediaFilteredReasons or []
-            reason_part = f": {reasons[0]}" if reasons else ""
-            raise Exception(
-                f"Content blocked by Google's Responsible AI filters{reason_part} "
-                f"({filtered_count} video{'s' if filtered_count != 1 else ''} filtered)."
-            )
+            raise RAIFilteredError(reasons=reasons, attempt=attempt)
 
         if response.videos:
             video = response.videos[0]
             if video.gcsUri:
-                media_id = await register_media_uri_with_ingest(cls, video.gcsUri, "video/mp4")
-                return IO.NodeOutput(media_id, ui={"video_uuid": [media_id]})
+                return await register_media_uri_with_ingest(cls, video.gcsUri, "video/mp4")
             raise Exception("Video returned but no data or URL was provided")
         raise Exception("Video generation completed but no video was returned")
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        negative_prompt: str,
+        resolution: str,
+        aspect_ratio: str,
+        duration: int,
+        seed: int,
+        first_frame_uuid: str | None = None,
+        last_frame_uuid: str | None = None,
+        model: str = "veo-3.1-lite-generate-001",
+        generate_audio: bool = True,
+    ):
+        model = MODELS_MAP[model]
+
+        # Resolve frame URIs once — they are stable across RAI retry attempts.
+        first_frame_task = (
+            asyncio.create_task(fetch_media_uri_from_ingest(cls, first_frame_uuid))
+            if first_frame_uuid else None
+        )
+        last_frame_task = (
+            asyncio.create_task(fetch_media_uri_from_ingest(cls, last_frame_uuid))
+            if last_frame_uuid else None
+        )
+        first_frame_uri = await first_frame_task if first_frame_task else None
+        last_frame_uri = await last_frame_task if last_frame_task else None
+
+        last_rai_error: RAIFilteredError | None = None
+        transient_attempt = 0
+
+        while True:
+            last_rai_error = None
+            try:
+                for attempt in range(1, _RAI_MAX_ATTEMPTS + 1):
+                    try:
+                        media_id = await cls._run_veo_generation(
+                            model=model,
+                            prompt=prompt,
+                            negative_prompt=negative_prompt,
+                            resolution=resolution,
+                            aspect_ratio=aspect_ratio,
+                            duration=duration,
+                            seed=seed,
+                            generate_audio=generate_audio,
+                            first_frame_uri=first_frame_uri,
+                            last_frame_uri=last_frame_uri,
+                            attempt=attempt,
+                        )
+                        return IO.NodeOutput(media_id, ui={"video_uuid": [media_id]})
+
+                    except RAIFilteredError as e:
+                        last_rai_error = e
+                        logger.warning(
+                            "[Veo3FirstLastFrameNode] RAI filter triggered (attempt %d/%d). "
+                            "Reasons: %s",
+                            attempt,
+                            _RAI_MAX_ATTEMPTS,
+                            e.reasons,
+                        )
+                        if attempt < _RAI_MAX_ATTEMPTS:
+                            await asyncio.sleep(_RAI_RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+
+                break  # RAI exhausted normally — exit while loop to return fallback
+
+            except VeoTransientError as e:
+                transient_attempt += 1
+                logger.warning(
+                    "[Veo3FirstLastFrameNode] Veo unavailable (gRPC %d), "
+                    "transient attempt %d/%d: %s",
+                    e.code,
+                    transient_attempt,
+                    _TRANSIENT_MAX_ATTEMPTS,
+                    e.message,
+                )
+                if transient_attempt >= _TRANSIENT_MAX_ATTEMPTS:
+                    logger.error(
+                        "[Veo3FirstLastFrameNode] Veo unavailable after %d transient attempts. "
+                        "Giving up.\nPrompt: %s",
+                        _TRANSIENT_MAX_ATTEMPTS,
+                        prompt,
+                    )
+                    raise
+                delay = _TRANSIENT_RETRY_BASE_DELAY * (2 ** (transient_attempt - 1))
+                logger.info(
+                    "[Veo3FirstLastFrameNode] Waiting %.0fs before retry...", delay
+                )
+                await asyncio.sleep(delay)
+
+        # RAI exhausted — log and return designated fallback placeholder.
+        logger.error(
+            "[Veo3FirstLastFrameNode] RAI filter exhausted after %d attempts. "
+            "Returning fallback UUID.\nPrompt: %s\nFinal reasons: %s",
+            _RAI_MAX_ATTEMPTS,
+            prompt,
+            last_rai_error.reasons if last_rai_error else [],
+        )
+        fallback = gemini_config.rai_fallback_video_uuid
+        return IO.NodeOutput(fallback, ui={"video_uuid": [fallback]})
+
+
 
 class VeoExtension(ComfyExtension):
     @override

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
@@ -201,10 +201,204 @@ class BaseUGCEditingNode(IO.ComfyNode):
         return IO.NodeOutput(output_media_id, ui={"video_uuid": [output_media_id]})
 
 
+class BatchUGCEditingNode(IO.ComfyNode):
+    """
+    Merges auto-batched video clips from one or more scene branches into a single video.
+
+    Each autogrow slot accepts the `video_uuid` output of one Veo branch.
+    With is_input_list=True, ComfyUI delivers each branch's full batch as a list,
+    so the node receives all clips without triggering N separate executions.
+
+    Clips are merged in slot order — all clips from slot 1 first, then slot 2, etc.
+    This gives you explicit control over scene ordering in the final video.
+
+    Example:
+        video_uuid_1 → [scene1_shot1, scene1_shot2, scene1_shot3]
+        video_uuid_2 → [scene2_shot1, scene2_shot2]
+        Result:        [s1_v1, s1_v2, s1_v3, s2_v1, s2_v2]
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="BatchUGCEditingNode",
+            display_name="Batch UGC Editing",
+            category="amplify/video editing",
+            description=(
+                "Merges auto-batched video clips from multiple scene branches into one video. "
+                "Wire each scene's Veo video_uuid output to a separate slot. "
+                "Clips are merged in slot order (scene 1 → scene 2 → …)."
+            ),
+            is_output_node=True,
+            is_input_list=True,
+            inputs=[
+                IO.Autogrow.Input(
+                    "scenes",
+                    template=IO.Autogrow.TemplatePrefix(
+                        IO.String.Input(
+                            "video_uuid",
+                            force_input=True,
+                            tooltip="Connect a Veo node's video_uuid output. All batch clips from this scene are collected in generation order.",
+                        ),
+                        prefix="video_uuid_",
+                        min=1,
+                        max=10,
+                    ),
+                    tooltip=(
+                        "One slot per scene branch. "
+                        "All clips from slot 1 are merged before slot 2, preserving scene order."
+                    ),
+                ),
+                IO.Boolean.Input(
+                    "remove_silence",
+                    default=False,
+                    tooltip="Remove silence/pauses from videos",
+                ),
+                IO.Boolean.Input(
+                    "add_captions",
+                    default=False,
+                    tooltip="Add auto-generated captions to the video",
+                ),
+                IO.String.Input(
+                    "caption_font",
+                    default="Arial",
+                    optional=True,
+                    advanced=True,
+                    tooltip="Font name for captions",
+                ),
+                IO.Int.Input(
+                    "caption_font_size",
+                    default=48,
+                    min=8,
+                    max=200,
+                    display_mode=IO.NumberDisplay.number,
+                    optional=True,
+                    advanced=True,
+                    tooltip="Font size for captions",
+                ),
+                IO.Boolean.Input(
+                    "add_music",
+                    default=False,
+                    tooltip="Add background music to the video",
+                ),
+                IO.String.Input(
+                    "music_id",
+                    force_input=True,
+                    optional=True,
+                    tooltip="Audio file UUID from Media Ingest",
+                ),
+                IO.Int.Input(
+                    "music_volume",
+                    default=50,
+                    min=0,
+                    max=100,
+                    display_mode=IO.NumberDisplay.slider,
+                    optional=True,
+                    advanced=True,
+                    tooltip="Background music volume (0–100)",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="video_uuid"),
+            ],
+            hidden=[Hidden.unique_id, Hidden.extra_pnginfo],
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        # is_input_list=True: each autogrow slot value arrives as a list[str] from
+        # the connected Veo auto-batch. Scalar inputs arrive as single-element lists.
+        scenes: dict[str, list[str] | str] | None = None,
+        remove_silence: list[bool] | None = None,
+        add_captions: list[bool] | None = None,
+        caption_font: list[str] | None = None,
+        caption_font_size: list[int] | None = None,
+        add_music: list[bool] | None = None,
+        music_id: list[str] | None = None,
+        music_volume: list[int] | None = None,
+    ) -> IO.NodeOutput:
+        # Flatten scenes dict in slot order: [s1_v1, s1_v2, s1_v3, s2_v1, s2_v2, …]
+        media_list: list[str] = []
+        if scenes:
+            for value in scenes.values():
+                if isinstance(value, list):
+                    media_list.extend(uid for uid in value if uid)
+                elif isinstance(value, str) and value:
+                    media_list.append(value)
+
+        if not media_list:
+            raise ValueError(
+                "No clips found. Connect at least one Veo node's video_uuid output "
+                "to a scene slot."
+            )
+
+        _remove_silence    = remove_silence[0]    if remove_silence    else False
+        _add_captions      = add_captions[0]      if add_captions      else False
+        _caption_font      = caption_font[0]      if caption_font      else "Arial"
+        _caption_font_size = caption_font_size[0] if caption_font_size else 48
+        _add_music         = add_music[0]         if add_music         else False
+        _music_id          = music_id[0]          if music_id          else None
+        _music_volume      = music_volume[0]      if music_volume      else 50
+
+        node_id = cls.hidden.unique_id or ""
+        extra_pnginfo = cls.hidden.extra_pnginfo or {}
+        user_id = extra_pnginfo.get("client_id", "")
+
+        base_url = video_editor_config.video_editor_url
+
+        request = SubmitTaskRequest(
+            video_id=str(uuid.uuid4()),
+            node_id=node_id,
+            user_id=user_id,
+            creation_args=BaseUgcCreationArgs(
+                media_files=media_list,
+                remove_silence=_remove_silence,
+                add_captions=_add_captions,
+                captions_settings=CaptionsSettings(
+                    font=_caption_font,
+                    font_size=_caption_font_size,
+                ) if _add_captions else None,
+                add_music=_add_music,
+                music_settings=MusicSettings(
+                    music_id=_music_id,
+                    volume=_music_volume / 100.0,
+                ) if _add_music and _music_id else None,
+            ),
+        )
+
+        submit_response = await sync_op(
+            cls,
+            ApiEndpoint(path=f"{base_url}/tasks", method="POST"),
+            response_model=SubmitTaskResponse,
+            data=request,
+            wait_label="Submitting batch video editing task...",
+        )
+
+        poll_response = await poll_op(
+            cls,
+            ApiEndpoint(path=f"{base_url}/tasks/{submit_response.task_id}", method="GET"),
+            response_model=TaskStatusResponse,
+            status_extractor=lambda r: r.status.lower(),
+            completed_statuses=["success"],
+            failed_statuses=["failure", "revoked"],
+            queued_statuses=["pending", "received", "retry"],
+            poll_interval=3.0,
+            estimated_duration=120,
+        )
+
+        if poll_response.status == "FAILURE":
+            raise Exception(f"Video editing failed: {poll_response.error}")
+
+        output_media_id = poll_response.result["outputMediaId"]
+        return IO.NodeOutput(output_media_id, ui={"video_uuid": [output_media_id]})
+
+
+
 class VideoEditorExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
-        return [BaseUGCEditingNode]
+        return [BaseUGCEditingNode, BatchUGCEditingNode]
 
 
 async def comfy_entrypoint() -> VideoEditorExtension:

--- a/template-service/backend_template/engine/comfy_api_nodes/util/__init__.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/util/__init__.py
@@ -18,6 +18,8 @@ from .request_utils import (
 
 from .broker import publish_event
 
+from .common_exceptions import RAIFilteredError, VeoTransientError
+
 __all__ = [
     # API client
     "ApiEndpoint",

--- a/template-service/backend_template/engine/comfy_api_nodes/util/common_exceptions.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/util/common_exceptions.py
@@ -12,3 +12,54 @@ class ApiServerError(NetworkError):
 
 class ProcessingInterrupted(Exception):
     """Operation was interrupted by user/runtime via processing_interrupted()."""
+
+
+class RAIFilteredError(Exception):
+    """
+    Raised when Veo returns raiMediaFilteredCount > 0.
+
+    RAI filtering is non-deterministic — the same prompt may pass on a subsequent
+    attempt. This exception is used as the retry signal in Veo execute() methods.
+
+    Attributes:
+        reasons:  List of filter reason strings returned by the API.
+        attempt:  The attempt number (1-based) that produced the block.
+    """
+
+    def __init__(self, reasons: list[str], attempt: int) -> None:
+        self.reasons = reasons
+        self.attempt = attempt
+        reason_part = f": {reasons[0]}" if reasons else ""
+        super().__init__(
+            f"Content blocked by Google's Responsible AI filters{reason_part} "
+            f"(attempt {attempt})"
+        )
+
+
+class VeoTransientError(Exception):
+    """
+    Raised when Veo LRO returns a retryable gRPC error inside a 200 OK response.
+
+    These errors arrive in poll_response.error and are NOT caught by sync_op's
+    HTTP-level retry logic. Only codes in RETRYABLE_CODES trigger retry —
+    all other LRO errors are raised as plain Exception immediately.
+
+    Retryable gRPC codes (mapped from Google's retryable HTTP codes):
+         4 — DEADLINE_EXCEEDED: operation timed out (HTTP 408 / 504).
+         8 — RESOURCE_EXHAUSTED: quota or rate limit hit (HTTP 429).
+        14 — UNAVAILABLE: service overloaded or in a rolling restart (HTTP 502/503).
+
+    Not retryable:
+        13 — INTERNAL: server-side bug; retrying is unlikely to help (HTTP 500).
+
+    Attributes:
+        message:  Error message from the API.
+        code:     gRPC status code integer.
+    """
+
+    RETRYABLE_CODES: frozenset[int] = frozenset({4, 8, 14})
+
+    def __init__(self, message: str, code: int) -> None:
+        self.message = message
+        self.code = code
+        super().__init__(f"Veo transient error (gRPC code {code}): {message}")

--- a/template-service/backend_template/engine/config.py
+++ b/template-service/backend_template/engine/config.py
@@ -11,6 +11,11 @@ class GeminiConfig(ConfigBase):
     project_id: str
     location: str
     storage_uri: str
+    # UUID of a pre-registered placeholder video in MediaIngest.
+    # Returned when Veo's RAI filter blocks a prompt after all retry attempts.
+    # This video must never be deleted — it acts as a visual marker in batches
+    # to identify which prompt was persistently filtered.
+    rai_fallback_video_uuid: str = "019da1f0-5775-74ae-91df-35661193c6d1"
 
 class MediaIngestConfig(ConfigBase):
     media_ingest_url: str = "http://localhost:5070/media/api"


### PR DESCRIPTION
- Add RAI content filter retry (3 attempts, 5s/10s backoff) in Veo3FirstLastFrameNode
- Add fallback mechanism: return placeholder UUID on RAI exhaustion (RAI_FALLBACK_VIDEO_UUID)
- Add VeoTransientError for retryable gRPC codes 4/8/14 (UNAVAILABLE, RESOURCE_EXHAUSTED, DEADLINE_EXCEEDED)
- Add transient retry outer loop (5 attempts, 30s->240s backoff) wrapping RAI retry
- Add BatchUGCEditingNode: merges auto-batched clips from multiple scene branches via is_input_list=True autogrow
- Export VeoTransientError from util package
- Add rai_fallback_video_uuid to GeminiConfig
Closes #330