### PR TITLE
fix(ci): prevent shell injection in telegram-notify action

### DIFF
--- a/.github/actions/telegram-notify/action.yaml
+++ b/.github/actions/telegram-notify/action.yaml
@@ -20,11 +20,16 @@ runs:
     steps:
         - name: Send Telegram Notification
           shell: bash
+          env:
+              TELEGRAM_MESSAGE: ${{ inputs.message }}
+              TELEGRAM_CHAT_ID: ${{ inputs.chat_id }}
+              TELEGRAM_THREAD_ID: ${{ inputs.topic_id }}
+              TELEGRAM_BOT_TOKEN: ${{ inputs.bot_token }}
           run: |
               JSON_PAYLOAD=$(jq -n \
-              --arg chat_id "${{ inputs.chat_id }}" \
-              --arg thread_id "${{ inputs.topic_id }}" \
-              --arg text "${{ inputs.message }}" \
+              --arg chat_id "$TELEGRAM_CHAT_ID" \
+              --arg thread_id "$TELEGRAM_THREAD_ID" \
+              --arg text "$TELEGRAM_MESSAGE" \
               '{
                   chat_id: $chat_id,
                   message_thread_id: $thread_id,
@@ -33,6 +38,6 @@ runs:
                   disable_web_page_preview: true
               }')
 
-              curl -s -X POST "https://api.telegram.org/bot${{ inputs.bot_token }}/sendMessage" \
+              curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
               -H "Content-Type: application/json" \
               -d "$JSON_PAYLOAD"


### PR DESCRIPTION
## What & Why

`${{ inputs.X }}` values expanded **inline** inside a `run: |` bash block are treated as raw shell text. The failure message built in `deploy-template.yaml` wraps the service name in backticks (e.g. `` `template-service` ``). When those backticks land inside the `--arg text "..."` string in the action script, bash interprets them as **command substitution**:

```
Error: /tmp/...sh: line 14: template-service: command not found
```

Side effects visible in CI:
- Every failed `deploy-template-service` run produces a spurious `command not found` error in the notification step
- The Telegram failure message shows `🔧 Сервис:` with an **empty** service name (the substitution result replaces the name with nothing)

## Fix

Move all four inputs to `env:` vars in the composite action step. The runner sets environment variables **before** the shell script executes — bash then reads them as plain `$VAR` references, never re-interpreting the content as shell commands.

```yaml
env:
    TELEGRAM_MESSAGE: ${{ inputs.message }}
    TELEGRAM_CHAT_ID: ${{ inputs.chat_id }}
    TELEGRAM_THREAD_ID: ${{ inputs.topic_id }}
    TELEGRAM_BOT_TOKEN: ${{ inputs.bot_token }}
```

## How to verify

Trigger any deploy that fails (or simulate by reverting a PR) — the notification step should now:
- Complete without `command not found`
- Show the correct service name in the Telegram message

🤖 Generated with [Claude Code](https://claude.com/claude-code)