### PR TITLE
AMPLIFY-365: Engine Job & Queue Management Endpoints

### DIFF
--- a/template-service/backend_template/auth.py
+++ b/template-service/backend_template/auth.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Annotated
 
 import aiohttp
@@ -10,6 +11,8 @@ from jwt.algorithms import RSAAlgorithm
 from backend_template.config import auth_config
 
 logger = logging.getLogger(__name__)
+
+SKIP_AUTH = os.getenv("SKIP_AUTH", "").lower() in ("1", "true", "yes")
 
 # ---------------------------------------------------------------------------
 # JWKS cache — fetched once on first request, refreshed on verification error
@@ -45,6 +48,12 @@ _bearer = HTTPBearer()
 
 
 async def _get_user_id(credentials: HTTPAuthorizationCredentials = Depends(_bearer)) -> str:
+    # ── SKIP_AUTH: skip JWT validation, use token value as user_id ──
+    if SKIP_AUTH:
+        user_id = credentials.credentials or "dev-user"
+        logger.warning("[SKIP_AUTH] Auth bypassed — user_id=%s", user_id)
+        return user_id
+
     token = credentials.credentials
 
     jwks = await _get_jwks()
@@ -101,3 +110,4 @@ async def _get_user_id(credentials: HTTPAuthorizationCredentials = Depends(_bear
 
 
 CurrentUserId = Annotated[str, Depends(_get_user_id)]
+

--- a/template-service/backend_template/engine/app/logger.py
+++ b/template-service/backend_template/engine/app/logger.py
@@ -11,5 +11,8 @@ def setup_logger(log_level='INFO'):
     logger = logging.getLogger()
     logger.setLevel(log_level)
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.setFormatter(logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    ))
     logger.addHandler(handler)

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_avatar_scene.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_avatar_scene.py
@@ -262,11 +262,11 @@ class AvatarSceneNode(IO.ComfyNode):
                 "Ensure the template is run via the JobService."
             )
 
-        from backend_template.database import async_session_maker
+        from backend_template.engine.database import engine_session_maker
         from backend_template.repositories.ambassador import AmbassadorRepository
 
         logger.info("[AvatarSceneNode] Looking up ambassador for project %s", project_id_str)
-        async with async_session_maker() as session:
+        async with engine_session_maker() as session:
             repo = AmbassadorRepository(session)
             ambassador = await repo.get_by_project_id(UUID(project_id_str))
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_script_supervisor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_script_supervisor.py
@@ -35,33 +35,15 @@ from uuid import UUID
 
 from comfy_api.latest import IO, ComfyExtension
 from comfy_api.latest._io import Hidden
-from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 from typing_extensions import override
 
 from comfy_api_nodes.context_keys import MEDIA_GEN_PARAMS, MEDIA_PROMPTS
-from comfy_api_nodes.util.broker import publish_event
+from server import PromptServer
 
 logger = logging.getLogger(__name__)
 
 NODE_TYPE = "script_supervisor"
 POLL_INTERVAL_SECONDS = 5.0
-
-
-# ── Internal event model ──────────────────────────────────────────────────────
-
-
-class _NodeStatusEvent(BaseModel):
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-
-    job_id: str
-    prompt_id: str = ""
-    node_id: str
-    user_id: str
-    status: str
-    outputs: dict | None = None
-    error: str | None = None
-    job_status: str | None = None
 
 
 # ── Node ──────────────────────────────────────────────────────────────────────
@@ -204,22 +186,16 @@ class ScriptSupervisorNode(IO.ComfyNode):
             )
             task_id = task.id
 
-        logger.info(
+        logger.debug(
             "[ScriptSupervisorNode] Created review task %s (shots=%d)",
             task_id,
             len(shots),
         )
 
-        # ── Notify frontend via RabbitMQ → WS Gateway ────────────────────────
-        user_id: str = extra_pnginfo.get("client_id", "")
-        await publish_event(
-            "node-status-changed",
-            _NodeStatusEvent(
-                job_id=job_id_str,
-                node_id=node_id_str,
-                user_id=user_id,
-                status="WAITING_FOR_REVIEW",
-            ),
+        # ── Notify via send_sync (same FIFO queue as engine events) ──────────
+        PromptServer.instance.send_sync(
+            "WAITING_FOR_REVIEW",
+            {"node": node_id_str, "prompt_id": extra_pnginfo.get("prompt_id", "")},
         )
 
         # ── Poll until the user approves ──────────────────────────────────────

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_script_supervisor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_script_supervisor.py
@@ -143,7 +143,7 @@ class ScriptSupervisorNode(IO.ComfyNode):
                 "Ensure the template is run via the JobService."
             )
 
-        from backend_template.database import async_session_maker
+        from backend_template.engine.database import engine_session_maker
         from backend_template.repositories.manual_review_task import ManualReviewTaskRepository
 
         job_id = UUID(job_id_str)
@@ -191,7 +191,7 @@ class ScriptSupervisorNode(IO.ComfyNode):
             return IO.NodeOutput(video_uuids, ui={"video_uuids": video_uuids})
 
         # ── Create the review task (only for actual human review) ─────────────
-        async with async_session_maker() as session:
+        async with engine_session_maker() as session:
             repo = ManualReviewTaskRepository(session)
             task = await repo.create(
                 job_id=job_id,
@@ -230,7 +230,7 @@ class ScriptSupervisorNode(IO.ComfyNode):
         while True:
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
-            async with async_session_maker() as session:
+            async with engine_session_maker() as session:
                 repo = ManualReviewTaskRepository(session)
                 task = await repo.get_by_id(task_id)
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
@@ -27,29 +27,14 @@ from uuid import UUID
 
 from comfy_api.latest import IO, ComfyExtension
 from comfy_api.latest._io import Hidden
-from pydantic import BaseModel, ConfigDict
-from pydantic.alias_generators import to_camel
 from typing_extensions import override
 
-from comfy_api_nodes.util.broker import publish_event
+from server import PromptServer
 
 logger = logging.getLogger(__name__)
 
 NODE_TYPE = "shot_review"
 POLL_INTERVAL_SECONDS = 5.0
-
-
-class _NodeStatusEvent(BaseModel):
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-
-    job_id: str
-    prompt_id: str = ""
-    node_id: str
-    user_id: str
-    status: str
-    outputs: dict | None = None
-    error: str | None = None
-    job_status: str | None = None
 
 
 class ShotReviewNode(IO.ComfyNode):
@@ -147,23 +132,17 @@ class ShotReviewNode(IO.ComfyNode):
             )
             task_id = task.id
 
-        logger.info(
+        logger.debug(
             "[ShotReviewNode] Created review task %s (auto_confirm=%s, videos=%d)",
             task_id,
             auto_confirm,
             len(video_uuids),
         )
 
-        # ── Notify frontend via RabbitMQ → WS Gateway ────────────────────
-        user_id: str = extra_pnginfo.get("client_id", "")
-        await publish_event(
-            "node-status-changed",
-            _NodeStatusEvent(
-                job_id=job_id_str,
-                node_id=node_id_str,
-                user_id=user_id,
-                status="WAITING_FOR_REVIEW",
-            ),
+        # ── Notify via send_sync (same FIFO queue as engine events) ────────
+        PromptServer.instance.send_sync(
+            "WAITING_FOR_REVIEW",
+            {"node": node_id_str, "prompt_id": extra_pnginfo.get("prompt_id", "")},
         )
 
         # ── Poll until the user submits their decision ────────────────────

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
@@ -117,7 +117,7 @@ class ShotReviewNode(IO.ComfyNode):
                 "Ensure the template is run via the JobService."
             )
 
-        from backend_template.database import async_session_maker
+        from backend_template.engine.database import engine_session_maker
         from backend_template.repositories.manual_review_task import ManualReviewTaskRepository
 
         job_id = UUID(job_id_str)
@@ -134,7 +134,7 @@ class ShotReviewNode(IO.ComfyNode):
             return IO.NodeOutput(video_uuids, ui={"video_uuids": video_uuids})
 
         # ── Create the review task ────────────────────────────────────────
-        async with async_session_maker() as session:
+        async with engine_session_maker() as session:
             repo = ManualReviewTaskRepository(session)
             task = await repo.create(
                 job_id=job_id,
@@ -171,7 +171,7 @@ class ShotReviewNode(IO.ComfyNode):
         while True:
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
-            async with async_session_maker() as session:
+            async with engine_session_maker() as session:
                 repo = ManualReviewTaskRepository(session)
                 task = await repo.get_by_id(task_id)
 

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
@@ -462,7 +462,7 @@ class BatchUGCEditingNode(IO.ComfyNode):
             ),
         )
 
-        logger.info(
+        logger.debug(
             "[BatchUGCEditingNode] Submitting task — %d clips from %d scenes, node=%s",
             len(media_list), len(scenes) if scenes else 0, node_id,
         )
@@ -476,7 +476,7 @@ class BatchUGCEditingNode(IO.ComfyNode):
             wait_label="Submitting batch video editing task...",
         )
 
-        logger.info(
+        logger.debug(
             "[BatchUGCEditingNode] Task submitted — task_id=%s, polling for completion",
             submit_response.task_id,
         )

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import Any
 
@@ -8,6 +9,8 @@ from comfy_api.latest import IO, ComfyExtension
 from comfy_api.latest._io import Hidden
 from comfy_api_nodes.util import ApiEndpoint, sync_op, poll_op
 from config import video_editor_config
+
+logger = logging.getLogger(__name__)
 
 
 # --- API response models ---
@@ -222,12 +225,23 @@ class BaseUGCEditingNode(IO.ComfyNode):
             ),
         )
 
+        logger.info(
+            "[BaseUGCEditingNode] Submitting task — %d media files, node=%s",
+            len(media_list), node_id,
+        )
+
         submit_response = await sync_op(
             cls,
             ApiEndpoint(path=f"{base_url}/tasks", method="POST"),
             response_model=SubmitTaskResponse,
             data=request,
+            timeout=60.0,
             wait_label="Submitting video editing task...",
+        )
+
+        logger.info(
+            "[BaseUGCEditingNode] Task submitted — task_id=%s, polling for completion",
+            submit_response.task_id,
         )
 
         poll_response = await poll_op(
@@ -237,17 +251,25 @@ class BaseUGCEditingNode(IO.ComfyNode):
             status_extractor=lambda r: r.status.lower(),
             completed_statuses=["success"],
             failed_statuses=["failure", "revoked"],
-            queued_statuses=["pending", "received", "retry"],
+            queued_statuses=["pending", "received"],
             poll_interval=3.0,
+            timeout_per_poll=30.0,
+            max_retries_per_poll=3,
             estimated_duration=120,
         )
 
         if poll_response.status == "FAILURE":
+            logger.error(
+                "[BaseUGCEditingNode] Task %s failed: %s",
+                submit_response.task_id, poll_response.error,
+            )
             raise Exception(f"Video editing failed: {poll_response.error}")
 
-        output_media_field_name = "outputMediaId"
-
-        output_media_id = poll_response.result[output_media_field_name]
+        output_media_id = poll_response.result["outputMediaId"]
+        logger.info(
+            "[BaseUGCEditingNode] Task %s completed — output=%s",
+            submit_response.task_id, output_media_id,
+        )
         return IO.NodeOutput(output_media_id, ui={"video_uuid": [output_media_id]})
 
 
@@ -440,12 +462,23 @@ class BatchUGCEditingNode(IO.ComfyNode):
             ),
         )
 
+        logger.info(
+            "[BatchUGCEditingNode] Submitting task — %d clips from %d scenes, node=%s",
+            len(media_list), len(scenes) if scenes else 0, node_id,
+        )
+
         submit_response = await sync_op(
             cls,
             ApiEndpoint(path=f"{base_url}/tasks", method="POST"),
             response_model=SubmitTaskResponse,
             data=request,
+            timeout=60.0,
             wait_label="Submitting batch video editing task...",
+        )
+
+        logger.info(
+            "[BatchUGCEditingNode] Task submitted — task_id=%s, polling for completion",
+            submit_response.task_id,
         )
 
         poll_response = await poll_op(
@@ -455,15 +488,25 @@ class BatchUGCEditingNode(IO.ComfyNode):
             status_extractor=lambda r: r.status.lower(),
             completed_statuses=["success"],
             failed_statuses=["failure", "revoked"],
-            queued_statuses=["pending", "received", "retry"],
+            queued_statuses=["pending", "received"],
             poll_interval=3.0,
+            timeout_per_poll=30.0,
+            max_retries_per_poll=3,
             estimated_duration=120,
         )
 
         if poll_response.status == "FAILURE":
+            logger.error(
+                "[BatchUGCEditingNode] Task %s failed: %s",
+                submit_response.task_id, poll_response.error,
+            )
             raise Exception(f"Video editing failed: {poll_response.error}")
 
         output_media_id = poll_response.result["outputMediaId"]
+        logger.info(
+            "[BatchUGCEditingNode] Task %s completed — output=%s",
+            submit_response.task_id, output_media_id,
+        )
         return IO.NodeOutput(output_media_id, ui={"video_uuid": [output_media_id]})
 
 

--- a/template-service/backend_template/engine/database.py
+++ b/template-service/backend_template/engine/database.py
@@ -1,0 +1,71 @@
+"""
+Dedicated async engine for the ComfyUI worker thread.
+
+The main ``backend_template.database`` engine is created at FastAPI startup and
+its connection pool is bound to the FastAPI event loop.  The engine worker
+thread creates its own persistent event loop (via ``asyncio.new_event_loop()``
+in ``prompt_worker``), so sharing the FastAPI engine would cause
+"Future attached to a different loop" errors.
+
+This module lazily creates a separate ``create_async_engine`` the first time a
+node calls ``engine_session_maker()``.  Because the worker loop is persistent
+(one loop for the lifetime of the thread), the engine is created once and its
+connection pool is reused across all prompt executions.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from asyncpg import Connection as AsyncPGConnection
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from backend_template.config import settings
+
+
+# Reuse the prepared-statement collision fix from the main database module.
+class _FixedAsyncConnection(AsyncPGConnection):
+    def _get_unique_id(self, prefix: str) -> str:
+        return f"__asyncpg_{prefix}_{uuid.uuid4()}__"
+
+
+_engine = None
+_session_maker = None
+
+
+def engine_session_maker() -> AsyncSession:
+    """Return an ``AsyncSession`` context manager bound to the worker loop.
+
+    Lazily creates a dedicated engine on first call.  Since the worker thread
+    uses a persistent event loop, the engine is created once and its pool is
+    reused across all prompt executions.
+
+    Usage inside nodes::
+
+        from backend_template.engine.database import engine_session_maker
+
+        async with engine_session_maker() as session:
+            ...
+    """
+    global _engine, _session_maker
+
+    if _session_maker is None:
+        _engine = create_async_engine(
+            url=settings.postgres_dsn,
+            echo=settings.postgres_echo,
+            connect_args={"connection_class": _FixedAsyncConnection},
+            pool_pre_ping=True,
+            pool_size=3,
+            max_overflow=5,
+        )
+        _session_maker = async_sessionmaker(
+            _engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+
+    return _session_maker()

--- a/template-service/backend_template/engine/execution.py
+++ b/template-service/backend_template/engine/execution.py
@@ -494,6 +494,12 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 # TODO - How to handle this with async functions without contextvars (which requires Python 3.12)?
                 GraphBuilder.set_default_prefix(unique_id, call_index, 0)
 
+            logging.info(
+                "[execute] Node %s (%s) — starting execute, prompt_id=%s",
+                unique_id, class_type, prompt_id,
+            )
+            node_start_ts = time.perf_counter()
+
             output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
 
             if has_pending_tasks:
@@ -553,12 +559,20 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
             pending_subgraph_results[unique_id] = cached_outputs
             return (ExecutionResult.PENDING, None, None)
 
+        logging.info(
+            "[execute] Node %s (%s) — completed in %.1fs, prompt_id=%s",
+            unique_id, class_type, time.perf_counter() - node_start_ts, prompt_id,
+        )
+
         cache_entry = CacheEntry(ui=ui_outputs.get(unique_id), outputs=output_data)
         execution_list.cache_update(unique_id, cache_entry)
         caches.outputs.set(unique_id, cache_entry)
 
     except comfy.model_management.InterruptProcessingException as iex:
-        logging.info("Processing interrupted")
+        logging.info(
+            "[execute] Node %s (%s) — INTERRUPTED after %.1fs, prompt_id=%s",
+            unique_id, class_type, time.perf_counter() - node_start_ts, prompt_id,
+        )
 
         # skip formatting inputs/outputs
         error_details = {
@@ -577,6 +591,10 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
 
         logging.error(f"!!! Exception during processing !!! {ex}")
         logging.error(traceback.format_exc())
+        logging.info(
+            "[execute] Node %s (%s) — FAILED after %.1fs: %s, prompt_id=%s",
+            unique_id, class_type, time.perf_counter() - node_start_ts, ex, prompt_id,
+        )
         tips = ""
 
         error_details = {

--- a/template-service/backend_template/engine/execution.py
+++ b/template-service/backend_template/engine/execution.py
@@ -498,7 +498,6 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 "[execute] Node %s (%s) — starting execute, prompt_id=%s",
                 unique_id, class_type, prompt_id,
             )
-            node_start_ts = time.perf_counter()
 
             output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
 
@@ -560,8 +559,8 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
             return (ExecutionResult.PENDING, None, None)
 
         logging.info(
-            "[execute] Node %s (%s) — completed in %.1fs, prompt_id=%s",
-            unique_id, class_type, time.perf_counter() - node_start_ts, prompt_id,
+            "[execute] Node %s (%s) — completed, prompt_id=%s",
+            unique_id, class_type, prompt_id,
         )
 
         cache_entry = CacheEntry(ui=ui_outputs.get(unique_id), outputs=output_data)
@@ -570,8 +569,8 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
 
     except comfy.model_management.InterruptProcessingException as iex:
         logging.info(
-            "[execute] Node %s (%s) — INTERRUPTED after %.1fs, prompt_id=%s",
-            unique_id, class_type, time.perf_counter() - node_start_ts, prompt_id,
+            "[execute] Node %s (%s) — INTERRUPTED, prompt_id=%s",
+            unique_id, class_type, prompt_id,
         )
 
         # skip formatting inputs/outputs
@@ -592,8 +591,8 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
         logging.error(f"!!! Exception during processing !!! {ex}")
         logging.error(traceback.format_exc())
         logging.info(
-            "[execute] Node %s (%s) — FAILED after %.1fs: %s, prompt_id=%s",
-            unique_id, class_type, time.perf_counter() - node_start_ts, ex, prompt_id,
+            "[execute] Node %s (%s) — FAILED: %s, prompt_id=%s",
+            unique_id, class_type, ex, prompt_id,
         )
         tips = ""
 

--- a/template-service/backend_template/engine/main.py
+++ b/template-service/backend_template/engine/main.py
@@ -25,7 +25,13 @@ import comfy.model_management
 
 def prompt_worker(q, server_instance, cache_type=execution.CacheType.NONE):
     current_time: float = 0.0
-    
+
+    # Create a persistent event loop for the worker thread.  This loop lives
+    # for the entire lifetime of the thread so that async DB engines / connection
+    # pools created by nodes remain valid across prompt executions.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     e = execution.PromptExecutor(server_instance, cache_type=cache_type)
     last_gc_collect = 0
     need_gc = False
@@ -48,7 +54,7 @@ def prompt_worker(q, server_instance, cache_type=execution.CacheType.NONE):
             for k in sensitive:
                 extra_data[k] = sensitive[k]
 
-            e.execute(item[2], prompt_id, extra_data, item[4])
+            loop.run_until_complete(e.execute_async(item[2], prompt_id, extra_data, item[4]))
             need_gc = True
 
             remove_sensitive = lambda prompt: prompt[:5] + prompt[6:]

--- a/template-service/backend_template/engine/main.py
+++ b/template-service/backend_template/engine/main.py
@@ -54,6 +54,11 @@ def prompt_worker(q, server_instance, cache_type=execution.CacheType.NONE):
             for k in sensitive:
                 extra_data[k] = sensitive[k]
 
+            logging.info(
+                "[prompt_worker] Starting prompt_id=%s client_id=%s",
+                prompt_id, extra_data.get("client_id", "N/A"),
+            )
+
             loop.run_until_complete(e.execute_async(item[2], prompt_id, extra_data, item[4]))
             need_gc = True
 

--- a/template-service/backend_template/engine/server.py
+++ b/template-service/backend_template/engine/server.py
@@ -332,7 +332,7 @@ class PromptServer():
         elif sid in self.sockets:
             await send_socket_catch_exception(self.sockets[sid].send_json, message)
 
-        _EXECUTION_EVENTS = {"executing", "execution_cached", "executed", "execution_error", "execution_success"}
+        _EXECUTION_EVENTS = {"execution_start", "executing", "execution_cached", "executed", "execution_error", "execution_interrupted", "execution_success"}
         if event in _EXECUTION_EVENTS:
             try:
                 await self._publish_exec_event(event, data)

--- a/template-service/backend_template/engine/server.py
+++ b/template-service/backend_template/engine/server.py
@@ -188,6 +188,9 @@ class PromptServer():
                         if sensitive_val in extra_data:
                             sensitive[sensitive_val] = extra_data.pop(sensitive_val)
                     extra_data["create_time"] = int(time.time() * 1000)  # timestamp in milliseconds
+                    # Inject prompt_id so nodes can reference it via extra_pnginfo
+                    if "extra_pnginfo" in extra_data:
+                        extra_data["extra_pnginfo"]["prompt_id"] = prompt_id
                     self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive))
 
                     # Store metadata for RabbitMQ event publishing
@@ -332,7 +335,7 @@ class PromptServer():
         elif sid in self.sockets:
             await send_socket_catch_exception(self.sockets[sid].send_json, message)
 
-        _EXECUTION_EVENTS = {"execution_start", "executing", "execution_cached", "executed", "execution_error", "execution_interrupted", "execution_success"}
+        _EXECUTION_EVENTS = {"execution_start", "executing", "execution_cached", "executed", "execution_error", "execution_interrupted", "execution_success", "WAITING_FOR_REVIEW"}
         if event in _EXECUTION_EVENTS:
             try:
                 await self._publish_exec_event(event, data)
@@ -411,6 +414,14 @@ class PromptServer():
             ))
             self.prompt_metadata.pop(prompt_id, None)
 
+        # ── Custom node status (e.g. HITL nodes) ─────────────────────
+        elif event == "WAITING_FOR_REVIEW":
+            node_id = data.get("node", "")
+            to_publish.append(_NodeStatusEvent(
+                job_id=job_id, prompt_id=prompt_id, node_id=node_id,
+                user_id=user_id, status="WAITING_FOR_REVIEW",
+            ))
+
         for ev in to_publish:
             try:
                 await publish_event("node-status-changed", ev)
@@ -418,7 +429,7 @@ class PromptServer():
                 logging.error(f"Failed to publish execution event: {e}")
 
     def send_sync(self, event, data, sid=None):
-        logging.info(f"[SERVER] send_sync {event} {data} {sid}")
+        # logging.debug(f"[SERVER] send_sync {event} {data} {sid}")
         self.loop.call_soon_threadsafe(
             self.messages.put_nowait, (event, data, sid))
 

--- a/template-service/backend_template/engine/server.py
+++ b/template-service/backend_template/engine/server.py
@@ -32,6 +32,9 @@ class _NodeStatusEvent(BaseModel):
     error: str | None = None
     job_status: str | None = None  # COMPLETED | FAILED on terminal events
 
+def _remove_sensitive_from_queue(queue: list) -> list:
+    """Remove sensitive data (index 5) from queue item tuples."""
+    return [item[:5] for item in queue]
 
 async def send_socket_catch_exception(function, message):
     try:
@@ -226,6 +229,60 @@ class PromptServer():
             prompt_id = request.match_info.get("prompt_id", None)
             return web.json_response(self.prompt_queue.get_history(prompt_id=prompt_id))
 
+        @routes.get("/queue")
+        async def get_queue(request):
+            queue_info = {}
+            current_queue = self.prompt_queue.get_current_queue_volatile()
+            queue_info['queue_running'] = _remove_sensitive_from_queue(current_queue[0])
+            queue_info['queue_pending'] = _remove_sensitive_from_queue(current_queue[1])
+            return web.json_response(queue_info)
+
+        @routes.post("/queue")
+        async def post_queue(request):
+            json_data =  await request.json()
+            if "clear" in json_data:
+                if json_data["clear"]:
+                    self.prompt_queue.wipe_queue()
+            if "delete" in json_data:
+                to_delete = json_data['delete']
+                for id_to_delete in to_delete:
+                    delete_func = lambda a: a[1] == id_to_delete
+                    self.prompt_queue.delete_queue_item(delete_func)
+
+            return web.Response(status=200)        
+
+        @routes.post("/interrupt")
+        async def post_interrupt(request):
+            try:
+                json_data = await request.json()
+            except json.JSONDecodeError:
+                json_data = {}
+
+            # Check if a specific prompt_id was provided for targeted interruption
+            prompt_id = json_data.get('prompt_id')
+            if prompt_id:
+                currently_running, _ = self.prompt_queue.get_current_queue()
+
+                # Check if the prompt_id matches any currently running prompt
+                should_interrupt = False
+                for item in currently_running:
+                    # item structure: (number, prompt_id, prompt, extra_data, outputs_to_execute)
+                    if item[1] == prompt_id:
+                        logging.info(f"Interrupting prompt {prompt_id}")
+                        should_interrupt = True
+                        break
+
+                if should_interrupt:
+                    nodes.interrupt_processing()
+                else:
+                    logging.info(f"Prompt {prompt_id} is not currently running, skipping interrupt")
+            else:
+                # No prompt_id provided, do a global interrupt
+                logging.info("Global interrupt (no prompt_id specified)")
+                nodes.interrupt_processing()
+
+            return web.Response(status=200)
+            
         @routes.post("/history")
         async def post_history(request):
             json_data =  await request.json()
@@ -297,7 +354,14 @@ class PromptServer():
 
         to_publish: list[_NodeStatusEvent] = []
 
-        if event == "executing":
+        if event == "execution_start":
+            to_publish.append(_NodeStatusEvent(
+                job_id=job_id, prompt_id=prompt_id, node_id="",
+                user_id=user_id, status="JOB_STARTED",
+                job_status="PROCESSING",
+            ))
+
+        elif event == "executing":
             node_id = data.get("node")
             if node_id is None:
                 return
@@ -328,6 +392,15 @@ class PromptServer():
                 job_id=job_id, prompt_id=prompt_id, node_id=node_id,
                 user_id=user_id, status="FAILURE", error=error,
                 job_status="FAILED",
+            ))
+            self.prompt_metadata.pop(prompt_id, None)
+
+        elif event == "execution_interrupted":
+            node_id = data.get("node_id", "")
+            to_publish.append(_NodeStatusEvent(
+                job_id=job_id, prompt_id=prompt_id, node_id=node_id,
+                user_id=user_id, status="CANCELLED",
+                job_status="CANCELLED",
             ))
             self.prompt_metadata.pop(prompt_id, None)
 

--- a/template-service/backend_template/entities/engine.py
+++ b/template-service/backend_template/entities/engine.py
@@ -95,3 +95,49 @@ class PromptResponse(BaseModel):
     number: int
     node_errors: dict
 
+
+# ---------------------------------------------------------------------------
+# Queue Info (GET /v1/engine/queue)
+# ---------------------------------------------------------------------------
+class QueueInfoResponse(BaseModel):
+    """Snapshot of the engine's volatile prompt queue."""
+
+    queue_running: list = Field(
+        default_factory=list,
+        description="Currently executing prompt(s).",
+    )
+    queue_pending: list = Field(
+        default_factory=list,
+        description="Prompts waiting to be executed (ordered by priority).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Queue Management (POST /v1/engine/queue)
+# ---------------------------------------------------------------------------
+class QueueManageRequest(BaseModel):
+    """Request body for managing the engine's prompt queue."""
+
+    delete: list[str] | None = Field(
+        default=None,
+        description="List of prompt_ids to remove from the pending queue.",
+    )
+    clear: bool | None = Field(
+        default=None,
+        description="If true, clear all pending prompts from the queue.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interrupt (POST /v1/engine/interrupt)
+# ---------------------------------------------------------------------------
+class InterruptRequest(BaseModel):
+    """Optional request body for targeted interrupt."""
+
+    prompt_id: str | None = Field(
+        default=None,
+        description="Interrupt a specific running prompt. "
+        "If omitted, interrupts the currently running prompt globally.",
+    )
+
+

--- a/template-service/backend_template/entities/job.py
+++ b/template-service/backend_template/entities/job.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -26,3 +27,40 @@ class NodeStatusChangedEvent(BaseModel):
     outputs: dict | None = None
     error: str | None = None
     job_status: str | None = None  # COMPLETED | FAILED — set on terminal events
+
+
+# ---------------------------------------------------------------------------
+# Job Detail (GET /v1/engine/jobs/{job_id})
+# ---------------------------------------------------------------------------
+class NodeExecutionResponse(BaseModel):
+    """Single node's execution state within a job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    node_id: UUID
+    class_name: str
+    status: str
+    inputs: dict | None = None
+    outputs: dict | None = None
+    error_message: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class JobDetailResponse(BaseModel):
+    """Full job details including per-node execution state."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    status: str
+    prompt_id: str | None = None
+    total_cost: float
+    template_version_id: UUID
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+    node_executions: list[NodeExecutionResponse] = []
+

--- a/template-service/backend_template/models/node_execution.py
+++ b/template-service/backend_template/models/node_execution.py
@@ -11,6 +11,7 @@ class NodeStatus(str, enum.Enum):
     RUNNING = "RUNNING"
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
+    CANCELLED = "CANCELLED"
     WAITING_FOR_REVIEW = "WAITING_FOR_REVIEW"
 
 class NodeExecution(Base, CommonMixin):

--- a/template-service/backend_template/services/engine_client.py
+++ b/template-service/backend_template/services/engine_client.py
@@ -76,6 +76,34 @@ class EngineClientService:
         )
         return PromptResponse.model_validate(data)
 
+    # ── Queue ─────────────────────────────────────────────────────────────
+
+    async def get_queue(self) -> dict:
+        """Proxy GET /api/queue → volatile queue snapshot (running + pending)."""
+        return await self._get(f"{settings.engine_base_url}/api/queue")
+
+    async def manage_queue(
+        self,
+        clear: bool | None = None,
+        delete: list[str] | None = None,
+    ) -> None:
+        """Proxy POST /api/queue → cancel pending prompts or clear queue."""
+        body: dict = {}
+        if clear is not None:
+            body["clear"] = clear
+        if delete is not None:
+            body["delete"] = delete
+        await self._post(f"{settings.engine_base_url}/api/queue", json=body)
+
+    # ── Interrupt ─────────────────────────────────────────────────────────
+
+    async def interrupt(self, prompt_id: str | None = None) -> None:
+        """Proxy POST /api/interrupt → stop the currently running graph."""
+        body: dict = {}
+        if prompt_id is not None:
+            body["prompt_id"] = prompt_id
+        await self._post(f"{settings.engine_base_url}/api/interrupt", json=body)
+
     # ── Private Helpers ───────────────────────────────────────────────────
 
     async def _get(self, url: str, params: dict | None = None) -> dict:

--- a/template-service/backend_template/services/job.py
+++ b/template-service/backend_template/services/job.py
@@ -9,10 +9,11 @@ import aiohttp
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from backend_template.config import settings
 from backend_template.database import get_db
-from backend_template.entities.job import RunTemplateResponse
+from backend_template.entities.job import JobDetailResponse, RunTemplateResponse
 from backend_template.models.job import Job, JobStatus
 from backend_template.models.node_execution import NodeExecution, NodeStatus
 from backend_template.models.product import Product
@@ -26,6 +27,18 @@ logger = logging.getLogger(__name__)
 class JobService:
     def __init__(self, db: Annotated[AsyncSession, Depends(get_db)]):
         self.db = db
+
+    async def get_job_detail(self, job_id: UUID) -> JobDetailResponse:
+        """Load a Job with all its NodeExecution records from the DB."""
+        result = await self.db.execute(
+            select(Job)
+            .options(selectinload(Job.node_executions))
+            .where(Job.id == job_id)
+        )
+        job = result.scalar_one_or_none()
+        if not job:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+        return JobDetailResponse.model_validate(job)
 
     async def run_template(self, template_id: UUID, user_id: str) -> RunTemplateResponse:
         template = await self.db.get(ProjectTemplate, template_id)
@@ -164,7 +177,6 @@ class JobService:
             )
 
         job.prompt_id = prompt_id
-        job.status = JobStatus.PROCESSING
         await self.db.commit()
 
         return RunTemplateResponse(job_id=str(job.id), prompt_id=prompt_id)

--- a/template-service/backend_template/services/job.py
+++ b/template-service/backend_template/services/job.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import os
 import uuid
 from uuid import UUID
 from typing import Annotated
@@ -22,6 +23,8 @@ from backend_template.models.template_version import TemplateVersion
 from backend_template.utils.graph import convert_reactflow_to_comfy
 
 logger = logging.getLogger(__name__)
+
+DEV_MODE = os.getenv("DEV_MODE", "").lower() in ("1", "true", "yes")
 
 
 class JobService:
@@ -69,8 +72,14 @@ class JobService:
             await self.db.flush()
 
         # Convert ReactFlow graph to ComfyUI prompt format
-        comfy_prompt = convert_reactflow_to_comfy(graph)
-        logger.warning(f"Converted comfy graph: {json.dumps(comfy_prompt, indent=2)}")
+        if DEV_MODE:
+            comfy_prompt = graph  # already in raw API format
+            logger.debug("[DEV_MODE] Skipping ReactFlow conversion — using graph as-is")
+        else:
+            comfy_prompt = convert_reactflow_to_comfy(graph)
+
+        logger.debug("Comfy prompt for engine:\n%s", json.dumps(comfy_prompt, indent=2))
+
         
         job = Job(
             template_version_id=template_version.id,

--- a/template-service/backend_template/services/job_consumer.py
+++ b/template-service/backend_template/services/job_consumer.py
@@ -8,7 +8,7 @@ import aio_pika
 from pydantic import BaseModel
 from pydantic.alias_generators import to_camel
 from pydantic import ConfigDict
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import selectinload
 
 from backend_template.config import settings
@@ -224,6 +224,20 @@ async def _finish_job(job_id: str, final_status: JobStatus) -> None:
             return
         job.status = final_status
         job.finished_at = datetime.now(timezone.utc)
+
+        # Wire-only nodes (e.g. StringInputNode, ConcatTextNode) don't produce
+        # output_ui, so the engine never emits an `executed` event for them.
+        # If the job completed successfully, these nodes must have succeeded.
+        if final_status == JobStatus.COMPLETED:
+            await db.execute(
+                update(NodeExecution)
+                .where(
+                    NodeExecution.job_id == job_uuid,
+                    NodeExecution.status == NodeStatus.RUNNING,
+                )
+                .values(status=NodeStatus.SUCCESS)
+            )
+
         await db.commit()
 
 

--- a/template-service/backend_template/services/job_consumer.py
+++ b/template-service/backend_template/services/job_consumer.py
@@ -29,6 +29,7 @@ _STATUS_MAP: dict[str, NodeStatus] = {
     "SUCCESS": NodeStatus.SUCCESS,
     "CACHED": NodeStatus.SUCCESS,
     "FAILURE": NodeStatus.FAILURE,
+    "CANCELLED": NodeStatus.CANCELLED,
     "WAITING_FOR_REVIEW": NodeStatus.WAITING_FOR_REVIEW,
 }
 
@@ -124,7 +125,10 @@ async def _handle_event(data: dict) -> None:
                 _last_media[job_id] = media
                 logger.info(f"Job {job_id}: cached last media {media}")
 
-    if job_status == "COMPLETED":
+    if job_status == "PROCESSING":
+        await _start_job(job_id)
+
+    elif job_status == "COMPLETED":
         await _finish_job(job_id, JobStatus.COMPLETED)
         if user_id:
             await _publish_graph_completed(job_id, user_id)
@@ -136,6 +140,10 @@ async def _handle_event(data: dict) -> None:
 
     elif job_status == "FAILED":
         await _finish_job(job_id, JobStatus.FAILED)
+        _last_media.pop(job_id, None)
+
+    elif job_status == "CANCELLED":
+        await _finish_job(job_id, JobStatus.CANCELLED)
         _last_media.pop(job_id, None)
 
 
@@ -186,6 +194,23 @@ async def _update_node_status(
             await db.commit()
 
 
+async def _start_job(job_id: str) -> None:
+    """Transition job from QUEUED → PROCESSING and set started_at."""
+    try:
+        job_uuid = uuid.UUID(job_id)
+    except (ValueError, AttributeError):
+        return
+
+    async with async_session_maker() as db:
+        result = await db.execute(select(Job).where(Job.id == job_uuid))
+        job = result.scalar_one_or_none()
+        if not job or job.status != JobStatus.QUEUED:
+            return
+        job.status = JobStatus.PROCESSING
+        job.started_at = datetime.now(timezone.utc)
+        await db.commit()
+
+
 async def _finish_job(job_id: str, final_status: JobStatus) -> None:
     try:
         job_uuid = uuid.UUID(job_id)
@@ -195,7 +220,7 @@ async def _finish_job(job_id: str, final_status: JobStatus) -> None:
     async with async_session_maker() as db:
         result = await db.execute(select(Job).where(Job.id == job_uuid))
         job = result.scalar_one_or_none()
-        if not job or job.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+        if not job or job.status in (JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED):
             return
         job.status = final_status
         job.finished_at = datetime.now(timezone.utc)

--- a/template-service/backend_template/web/routes/http/v1/engine.py
+++ b/template-service/backend_template/web/routes/http/v1/engine.py
@@ -1,15 +1,22 @@
 from typing import Annotated
-import uuid
+from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Query, status
 
 from backend_template.auth import CurrentUserId, _get_user_id
 from backend_template.entities.engine import (
     HistoryEntry,
+    InterruptRequest,
     PromptRequest,
     PromptResponse,
+    QueueInfoResponse,
+    QueueManageRequest,
 )
-from backend_template.entities.job import RunTemplateRequest, RunTemplateResponse
+from backend_template.entities.job import (
+    JobDetailResponse,
+    RunTemplateRequest,
+    RunTemplateResponse,
+)
 from backend_template.services.engine_client import EngineClientService
 from backend_template.services.job import JobService
 
@@ -81,6 +88,89 @@ async def run_template(
     highlight the broken nodes.
     """
     return await service.run_template(payload.template_id, user_id=user_id)
+
+
+# ── Job Details (DB Read) ────────────────────────────────────────────────
+
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=JobDetailResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get full job details",
+)
+async def get_job_detail(
+    job_id: UUID,
+    service: JobSvc,
+):
+    """
+    Returns the persistent job record with all node execution states.
+    Used by the frontend on page reload to reconstruct execution state
+    from the DB rather than relying on volatile WS/cache state.
+    """
+    return await service.get_job_detail(job_id)
+
+
+# ── Queue (Engine Proxy) ─────────────────────────────────────────────────
+
+
+@router.get(
+    "/queue",
+    response_model=QueueInfoResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get queue information",
+)
+async def get_queue(
+    service: Service,
+):
+    """
+    Returns a snapshot of the engine's volatile prompt queue:
+    currently running prompt(s) and pending prompts ordered by priority.
+    """
+    data = await service.get_queue()
+    return QueueInfoResponse.model_validate(data)
+
+
+@router.post(
+    "/queue",
+    status_code=status.HTTP_200_OK,
+    summary="Manage queue operations",
+)
+async def manage_queue(
+    payload: QueueManageRequest,
+    service: Service,
+):
+    """
+    Cancel specific pending prompts by prompt_id or clear the entire
+    pending queue.  Only affects pending prompts — to stop a running
+    graph, use ``POST /interrupt``.
+    """
+    await service.manage_queue(clear=payload.clear, delete=payload.delete)
+
+
+# ── Interrupt (Engine Proxy) ─────────────────────────────────────────────
+
+
+@router.post(
+    "/interrupt",
+    status_code=status.HTTP_200_OK,
+    summary="Interrupt currently running job",
+)
+async def interrupt(
+    service: Service,
+    payload: InterruptRequest | None = None,
+):
+    """
+    Sends an interrupt signal to the engine.  If ``prompt_id`` is provided,
+    only that specific prompt is interrupted (if it is currently running).
+    Otherwise, a global interrupt is issued.
+
+    The engine sets ``processing_interrupted()`` flag, which causes
+    ``sleep_with_interrupt`` to raise ``ProcessingInterrupted`` in the
+    active node's retry/poll loop.
+    """
+    prompt_id = payload.prompt_id if payload else None
+    await service.interrupt(prompt_id=prompt_id)
 
 
 # ── Prompt Submission ─────────────────────────────────────────────────────
@@ -157,4 +247,5 @@ async def clear_history(
     specific entries by prompt_id (if `delete` list is provided).
     """
     await service.clear_history(clear=clear, delete=delete)
+
 

--- a/template-service/docker-compose.yaml
+++ b/template-service/docker-compose.yaml
@@ -15,6 +15,20 @@ services:
       timeout: 5s
       retries: 5
 
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   api:
     build: .
     volumes:
@@ -23,8 +37,13 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+      - SKIP_AUTH=true
     depends_on:
       db:
+        condition: service_healthy
+      rabbitmq:
         condition: service_healthy
 
   pgadmin:


### PR DESCRIPTION
Closes #365

## What was done

Added engine control plane and job detail endpoints to the FastAPI gateway, plus fixed the job execution lifecycle.

### New Endpoints
- `GET /v1/engine/jobs/{job_id}` — persistent job details with per-node execution state (DB read)
- `GET /v1/engine/queue` — volatile queue snapshot (engine proxy)
- `POST /v1/engine/queue` — cancel pending prompts or clear queue (engine proxy)
- `POST /v1/engine/interrupt` — interrupt currently running graph (engine proxy)

### Lifecycle Fixes
- **execution_start handling** — job now transitions QUEUED → PROCESSING when the engine actually begins executing (not at prompt submission), with accurate `started_at` timestamp
- **execution_interrupted handling** — between-node interrupts (`InterruptProcessingException`) now publish `CANCELLED` job status via RabbitMQ instead of being silently dropped (zombie job fix)
- **CANCELLED status** — added to `NodeStatus` enum and `_STATUS_MAP` so interrupted nodes are correctly marked; added to `_finish_job` terminal state guard

### Files Changed
- `engine/server.py` — `execution_start` and `execution_interrupted` event handlers in `publish_exec_event`
- `entities/engine.py` — `QueueInfoResponse`, `QueueManageRequest`, `InterruptRequest` schemas
- `entities/job.py` — `JobDetailResponse`, `NodeExecutionResponse` schemas
- `models/node_execution.py` — `CANCELLED` added to `NodeStatus` enum
- `services/engine_client.py` — `get_queue()`, `manage_queue()`, `interrupt()` proxy methods
- `services/job.py` — `get_job_detail()` method; removed premature PROCESSING transition
- `services/job_consumer.py` — `_start_job()` helper; PROCESSING/CANCELLED handlers; terminal state guard update
- `web/routes/http/v1/engine.py` — 4 new route handlers