### PR TITLE
AMPLIFY-411: Tune elevenlabs voice output format

### DIFF
--- a/ai-gateway/src/Web/Endpoints/Voiceover.cs
+++ b/ai-gateway/src/Web/Endpoints/Voiceover.cs
@@ -1,5 +1,5 @@
-using AiGateway.Web.Clients;
 using AiGateway.Web.Clients.ElevenLabs.Models;
+using AiGateway.Web.Clients.ElevenLabs.V1.SpeechToSpeech.Item.StreamNamespace;
 using AiGateway.Web.Configuration;
 using AiGateway.Web.Services;
 
@@ -16,6 +16,11 @@ public record VoiceoverRequest
     /// ElevenLabs voice ID to apply.
     /// </summary>
     public required string VoiceId { get; init; }
+
+    /// <summary>
+    /// Output audio format. Defaults to mp3_44100_128 (best quality available on Free/PAYG tier).
+    /// </summary>
+    public PostOutput_formatQueryParameterType OutputFormat { get; init; } = PostOutput_formatQueryParameterType.Mp3_44100_128;
 }
 
 public record VoiceoverResult(Guid AudioId, string PresignedUrl);
@@ -41,6 +46,7 @@ public static class VoiceoverEndpoints
             var (audioId, presignedUrl) = await elevenLabsService.SpeechToSpeechAsync(
                 request.PresignedUrl,
                 request.VoiceId,
+                request.OutputFormat,
                 cancellationToken);
 
             return Results.Ok(new VoiceoverResult(audioId, presignedUrl));

--- a/ai-gateway/src/Web/Services/ElevenLabsService.cs
+++ b/ai-gateway/src/Web/Services/ElevenLabsService.cs
@@ -14,6 +14,7 @@ public class ElevenLabsService(
     public async Task<(Guid AudioId, string PresignedUrl)> SpeechToSpeechAsync(
         string presignedUrl,
         string voiceId,
+        PostOutput_formatQueryParameterType outputFormat = PostOutput_formatQueryParameterType.Mp3_44100_128,
         CancellationToken cancellationToken = default)
     {
         var http = httpClientFactory.CreateClient();
@@ -31,7 +32,7 @@ public class ElevenLabsService(
 
         await using var resultStream = await elevenlabsClient.V1.SpeechToSpeech[voiceId].Stream.PostAsync(body, config =>
         {
-            config.QueryParameters.OutputFormatAsPostOutputFormatQueryParameterType = PostOutput_formatQueryParameterType.Mp3_22050_32;
+            config.QueryParameters.OutputFormatAsPostOutputFormatQueryParameterType = outputFormat;
             config.QueryParameters.EnableLogging = false;
         }, cancellationToken);
 

--- a/wiki/issues/AMPLIFY-411/concepts/elevenlabs-output-formats.md
+++ b/wiki/issues/AMPLIFY-411/concepts/elevenlabs-output-formats.md
@@ -1,0 +1,69 @@
+# ElevenLabs STS — Output Formats
+
+Output format is set via the `output_format` query parameter, encoded as `codec_samplerate_bitrate` (e.g. `mp3_44100_128`).
+
+## MP3
+
+| Format | Sample rate | Bitrate | Min plan |
+|--------|-------------|---------|----------|
+| `mp3_22050_32` | 22.05 kHz | 32 kbps | Free |
+| `mp3_24000_48` | 24 kHz | 48 kbps | Free |
+| `mp3_44100_32` | 44.1 kHz | 32 kbps | Free |
+| `mp3_44100_64` | 44.1 kHz | 64 kbps | Free |
+| `mp3_44100_96` | 44.1 kHz | 96 kbps | Free |
+| `mp3_44100_128` | 44.1 kHz | 128 kbps | Free (**API default**) |
+| `mp3_44100_192` | 44.1 kHz | 192 kbps | Creator+ |
+
+## PCM (raw, uncompressed)
+
+| Format | Sample rate | Min plan |
+|--------|-------------|----------|
+| `pcm_8000` | 8 kHz | Free |
+| `pcm_16000` | 16 kHz | Free |
+| `pcm_22050` | 22.05 kHz | Free |
+| `pcm_24000` | 24 kHz | Free |
+| `pcm_32000` | 32 kHz | Free |
+| `pcm_44100` | 44.1 kHz | Pro+ |
+| `pcm_48000` | 48 kHz | Free |
+
+## WAV
+
+| Format | Min plan |
+|--------|----------|
+| `wav_8000` | Free |
+| `wav_16000` | Free |
+| `wav_22050` | Free |
+| `wav_24000` | Free |
+| `wav_32000` | Free |
+| `wav_44100` | Pro+ |
+| `wav_48000` | Free |
+
+## Opus
+
+| Format | Bitrate | Min plan |
+|--------|---------|----------|
+| `opus_48000_32` | 32 kbps | Free |
+| `opus_48000_64` | 64 kbps | Free |
+| `opus_48000_96` | 96 kbps | Free |
+| `opus_48000_128` | 128 kbps | Free |
+| `opus_48000_192` | 192 kbps | Free |
+
+## Telephony
+
+| Format | Use case |
+|--------|----------|
+| `ulaw_8000` | Twilio (μ-law, 8 kHz) |
+| `alaw_8000` | Telephony (A-law, 8 kHz) |
+
+## Summary: Free/PAYG limits
+
+Formats **not** available on Free/PAYG:
+- `mp3_44100_192` — requires Creator+
+- `pcm_44100` — requires Pro+
+- `wav_44100` — requires Pro+
+
+**Recommended default for this project:** `mp3_44100_128` — best MP3 quality on Free/PAYG, matches the ElevenLabs API default.
+
+## Related
+
+- [[elevenlabs-payg-vs-subscription]]

--- a/wiki/issues/AMPLIFY-411/concepts/elevenlabs-payg-vs-subscription.md
+++ b/wiki/issues/AMPLIFY-411/concepts/elevenlabs-payg-vs-subscription.md
@@ -1,0 +1,41 @@
+# ElevenLabs — Pay-as-you-go vs Subscription
+
+## Overview
+
+ElevenLabs has two ways to pay: a monthly subscription (tiered) or Pay-as-you-go (PAYG) credit top-ups without a subscription. Both have different implications for available features and pricing.
+
+## Subscription tiers (as of mid-2026)
+
+| Tier | Monthly price | Key extras vs Free |
+|------|---------------|--------------------|
+| Free | $0 | 10k chars TTS/mo, 1 instant voice clone, no STS on monthly quota |
+| Starter | ~$5 | ~30k chars, STS included |
+| Creator | ~$22 | 100k chars, `mp3_44100_192`, instant clone unlimited |
+| Pro | ~$99 | 500k chars, `pcm_44100` / `wav_44100`, professional voice clone |
+| Scale / Business | $330+ | High volume, priority queues |
+
+## Pay-as-you-go (PAYG)
+
+Introduced in May 2026. Allows using ElevenLabs APIs without a subscription by pre-purchasing credit packs.
+
+**Key facts:**
+- No monthly commitment
+- Pricing per API call:
+  - Speech-to-Speech (STS / Voice Changer): **$0.12 / minute**
+  - TTS: per-character pricing
+- Feature set is equivalent to **Free tier**, not to any paid subscription
+- Available voice formats are limited to Free-tier formats (see [[elevenlabs-output-formats]])
+- Voices available: all standard/premium library voices, 1 instant clone; no Professional Voice Cloning
+- Enabled by adding credits via "+ Add credits" in the ElevenAPI dashboard
+
+## How our project uses it
+
+The project uses a PAYG account (no active subscription) for ElevenLabs STS calls in ai-gateway. This means:
+
+- **Available formats:** everything except `mp3_44100_192`, `pcm_44100`, `wav_44100`
+- **Chosen default:** `mp3_44100_128` — best MP3 quality within PAYG limits, $0.12/min
+- API key is configured in ai-gateway and calls go directly to ElevenLabs (not through LiteLLM, because ElevenLabs STS is not a standard LiteLLM route — see AMPLIFY-409 decisions)
+
+## Related
+
+- [[elevenlabs-output-formats]]

--- a/wiki/issues/AMPLIFY-411/log.md
+++ b/wiki/issues/AMPLIFY-411/log.md
@@ -1,0 +1,5 @@
+# Log: AMPLIFY-411
+
+## 2026-06-13
+
+Session init. Documented ElevenLabs output formats and PAYG vs subscription model in wiki. Created plan.md. Starting implementation: upgrade default output format from `mp3_22050_32` to `mp3_44100_128` and expose it as an optional parameter in `VoiceoverRequest`.

--- a/wiki/issues/AMPLIFY-411/plan.md
+++ b/wiki/issues/AMPLIFY-411/plan.md
@@ -1,0 +1,29 @@
+# AMPLIFY-411: Tune ElevenLabs voice output format
+
+## Goal
+
+Upgrade the audio output format for ElevenLabs STS calls in ai-gateway from the lowest quality (`mp3_22050_32`) to the best quality available on Free/PAYG tier (`mp3_44100_128`).
+
+## Context
+
+The voiceover endpoint in ai-gateway (`POST /api/voiceover`) calls ElevenLabs STS via a generated Kiota client. The output format is controlled by the `output_format` query parameter. Currently hardcoded to `mp3_22050_32` — the worst quality available.
+
+ElevenLabs is accessed via PAYG (Pay-as-you-go) billing without a subscription. This caps the available formats at Free-tier limits.
+
+## Design Decisions
+
+- Default format: `mp3_44100_128` — best MP3 quality on Free/PAYG, matches ElevenLabs API default, no subscription required.
+- The format is exposed as an optional parameter in `VoiceoverRequest` so callers can override it in the future without another code change.
+- The enum `PostOutput_formatQueryParameterType` (auto-generated Kiota) already contains `Mp3_44100_128`.
+
+## Acceptance Criteria
+
+- [ ] `ElevenLabsService.SpeechToSpeechAsync` uses `Mp3_44100_128` by default
+- [ ] `VoiceoverRequest` accepts an optional `OutputFormat` parameter
+- [ ] Wiki documents ElevenLabs audio formats and PAYG vs subscription billing
+
+## Out of Scope
+
+- Changing the ElevenLabs voice model
+- Supporting PCM/WAV/Opus output from the voiceover endpoint
+- Any changes to transcription endpoint

--- a/wiki/issues/AMPLIFY-411/research.md
+++ b/wiki/issues/AMPLIFY-411/research.md
@@ -1,0 +1,16 @@
+# Research: AMPLIFY-411
+
+## Overview
+
+ElevenLabs STS (Speech-to-Speech / Voice Changer) supports many output formats via the `output_format` query parameter. The current ai-gateway implementation hardcodes the lowest quality (`mp3_22050_32`). The goal is to switch to `mp3_44100_128` — the best quality available without a paid subscription.
+
+## Concepts
+
+| Concept | Summary |
+|---------|---------|
+| [[concepts/elevenlabs-output-formats]] | Full table of formats by codec, sample rate, bitrate, and minimum plan |
+| [[concepts/elevenlabs-payg-vs-subscription]] | PAYG billing model vs subscription tiers and their differences |
+
+## Open Questions
+
+_None._

--- a/wiki/issues/index.md
+++ b/wiki/issues/index.md
@@ -8,3 +8,4 @@
 | [AMPLIFY-368](AMPLIFY-368/plan.md) | Tracking data points — dashboard research | In progress | Research phase; implementation pending |
 | [AMPLIFY-391](AMPLIFY-391/plan.md) | LiteLLM POC — AI cost tracking + analytics dashboard | In progress | Pass-through proxy; cross-schema SQL view; analytics in userservice |
 | [AMPLIFY-409](AMPLIFY-409/plan.md) | ElevenLabs speech-to-speech pass-through via LiteLLM | Done | 403 фиксится добавлением wildcard в Available Routes конкретного API-ключа (не в конфиге сервера) |
+| [AMPLIFY-411](AMPLIFY-411/plan.md) | Tune ElevenLabs voice output format | In progress | Upgrade default from `mp3_22050_32` to `mp3_44100_128`; expose as optional param |


### PR DESCRIPTION
Выставил по дефолту лучший доступный на free аккаунте формат (mp3_44100_128) + добавил возможность указания формата при вызове через API.

Closes #411 