### PR TITLE
AMPLIFY-425: Fix shot trim decisions lost on cached graph re-runs

### DIFF
--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_shot_review.py
@@ -16,12 +16,19 @@ Flow
 5. Merge the user's decision into ``extra_pnginfo["shot_decisions"]`` so that
    downstream nodes (e.g. VideoEditorNode) can read trim points without an
    explicit wire connection. Multiple ShotReviewNodes merge their decisions.
-6. Return the original ``video_uuids`` list as the sole output.
+6. Return the original ``video_uuids`` list as the first output and a
+   JSON-encoded dict of this node's trim decisions as the second output
+   (``shot_decisions_json``). Wiring this second output to a
+   ``BatchUGCEditingNode`` ensures the decisions survive cache hits on
+   subsequent graph re-runs — the cached output tuple is returned by the
+   engine without re-executing this node, so downstream nodes always receive
+   the correct trim decisions.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from uuid import UUID
 
@@ -78,6 +85,14 @@ class ShotReviewNode(IO.ComfyNode):
                     is_output_list=True,
                     tooltip="Same video UUIDs passed through after review.",
                 ),
+                IO.String.Output(
+                    display_name="shot_decisions_json",
+                    tooltip=(
+                        "JSON-encoded dict of trim decisions keyed by media UUID "
+                        "({uuid: {trimStart: float, trimEnd: float}}). "
+                        "Wire to BatchUGCEditingNode so decisions survive cache hits."
+                    ),
+                ),
             ],
         )
 
@@ -116,7 +131,7 @@ class ShotReviewNode(IO.ComfyNode):
             logger.info("[ShotReviewNode] auto_confirm=True, resolving immediately")
             existing = extra_pnginfo.get("shot_decisions", {})
             extra_pnginfo["shot_decisions"] = {**existing}
-            return IO.NodeOutput(video_uuids, ui={"video_uuids": video_uuids})
+            return IO.NodeOutput(video_uuids, json.dumps({}), ui={"video_uuids": video_uuids})
 
         # ── Create the review task ────────────────────────────────────────
         async with engine_session_maker() as session:
@@ -166,7 +181,7 @@ class ShotReviewNode(IO.ComfyNode):
                 )
                 existing = extra_pnginfo.get("shot_decisions", {})
                 extra_pnginfo["shot_decisions"] = {**existing, **decision}
-                return IO.NodeOutput(video_uuids, ui={"video_uuids": video_uuids})
+                return IO.NodeOutput(video_uuids, json.dumps(decision), ui={"video_uuids": video_uuids})
 
             logger.debug(
                 "[ShotReviewNode] Task %s status=%r, still waiting …",

--- a/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
+++ b/template-service/backend_template/engine/comfy_api_nodes/nodes_video_editor.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import uuid
 from typing import Any
@@ -154,6 +155,17 @@ class BaseUGCEditingNode(IO.ComfyNode):
                     advanced=True,
                     tooltip="Background music volume (0–100)",
                 ),
+                IO.String.Input(
+                    "shot_decisions_json",
+                    force_input=True,
+                    optional=True,
+                    tooltip=(
+                        "Wire the 'shot_decisions_json' output of the upstream "
+                        "ShotReviewNode here. When connected, trim decisions are "
+                        "read from this wire and are cache-safe. Falls back to "
+                        "execution-context side-channel when not wired."
+                    ),
+                ),
             ],
             outputs=[
                 IO.String.Output(display_name="video_uuid"),
@@ -174,6 +186,7 @@ class BaseUGCEditingNode(IO.ComfyNode):
         add_music: list[bool] | None = None,
         music_id: list[str | None] | None = None,
         music_volume: list[int] | None = None,
+        shot_decisions_json: list[str | None] | None = None,
     ) -> IO.NodeOutput:
         # is_input_list=True — each autogrow slot may carry a full list (from a
         # list-output node like ShotReviewNode); flatten all slots in order.
@@ -204,7 +217,17 @@ class BaseUGCEditingNode(IO.ComfyNode):
         extra_pnginfo = cls.hidden.extra_pnginfo or {}
         user_id = extra_pnginfo.get("client_id", "")
 
-        raw_decisions: dict | None = extra_pnginfo.get("shot_decisions")
+        # Prefer wired decisions (cache-safe) over extra_pnginfo side-channel.
+        # When ShotReviewNode is a cache hit its execute() never runs, so the
+        # side-channel write is skipped; the wired output carries the cached value.
+        _wired_json = shot_decisions_json[0] if shot_decisions_json else None
+        if _wired_json:
+            try:
+                raw_decisions: dict | None = json.loads(_wired_json)
+            except (json.JSONDecodeError, TypeError):
+                raw_decisions = None
+        else:
+            raw_decisions = extra_pnginfo.get("shot_decisions")
         trim_decisions: dict[str, TrimDecision] | None = None
         if raw_decisions:
             trim_decisions = {
@@ -401,6 +424,17 @@ class BatchUGCEditingNode(IO.ComfyNode):
                     advanced=True,
                     tooltip="Background music volume (0–100)",
                 ),
+                IO.String.Input(
+                    "shot_decisions_json",
+                    force_input=True,
+                    optional=True,
+                    tooltip=(
+                        "Wire the 'shot_decisions_json' output of the upstream "
+                        "ShotReviewNode here. When connected, trim decisions are "
+                        "read from this wire and are cache-safe. Falls back to "
+                        "execution-context side-channel when not wired."
+                    ),
+                ),
             ],
             outputs=[
                 IO.String.Output(display_name="video_uuid"),
@@ -423,6 +457,7 @@ class BatchUGCEditingNode(IO.ComfyNode):
         add_music: list[bool] | None = None,
         music_id: list[str] | None = None,
         music_volume: list[int] | None = None,
+        shot_decisions_json: list[str | None] | None = None,
     ) -> IO.NodeOutput:
         # Flatten scenes dict in slot order: [s1_v1, s1_v2, s1_v3, s2_v1, s2_v2, …]
         media_list: list[str] = []
@@ -453,7 +488,17 @@ class BatchUGCEditingNode(IO.ComfyNode):
         extra_pnginfo = cls.hidden.extra_pnginfo or {}
         user_id = extra_pnginfo.get("client_id", "")
 
-        raw_decisions: dict | None = extra_pnginfo.get("shot_decisions")
+        # Prefer wired decisions (cache-safe) over extra_pnginfo side-channel.
+        # When ShotReviewNode is a cache hit its execute() never runs, so the
+        # side-channel write is skipped; the wired output carries the cached value.
+        _wired_json = shot_decisions_json[0] if shot_decisions_json else None
+        if _wired_json:
+            try:
+                raw_decisions: dict | None = json.loads(_wired_json)
+            except (json.JSONDecodeError, TypeError):
+                raw_decisions = None
+        else:
+            raw_decisions = extra_pnginfo.get("shot_decisions")
         trim_decisions: dict[str, TrimDecision] | None = None
         if raw_decisions:
             trim_decisions = {

--- a/template-service/migrations/versions/2026-06-18_00-00-00_e5f6a7b8c9d0_add_node_result_cache.py
+++ b/template-service/migrations/versions/2026-06-18_00-00-00_e5f6a7b8c9d0_add_node_result_cache.py
@@ -1,0 +1,45 @@
+"""add node_result_cache table
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-18 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "e5f6a7b8c9d0"
+down_revision = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "template_service"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "node_result_cache",
+        sa.Column("input_hash", sa.Text(), nullable=False),
+        sa.Column("class_type", sa.Text(), nullable=False),
+        sa.Column("output", postgresql.JSONB(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("input_hash", name="pk_node_result_cache"),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_node_result_cache_expires_at",
+        "node_result_cache",
+        ["expires_at"],
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_node_result_cache_expires_at", table_name="node_result_cache", schema=SCHEMA)
+    op.drop_table("node_result_cache", schema=SCHEMA)


### PR DESCRIPTION
## What

On variation runs (hook-only re-run, seed change), `ShotReviewNode` for base branches
becomes a cache hit — `execute()` is skipped, so the `extra_pnginfo["shot_decisions"]`
side-channel write never fires. Downstream `BatchUGCEditingNode` then receives
`trim_decisions=None` and submits clips uncut, producing a longer video.

## Fix

`ShotReviewNode` now emits a second wired output — `shot_decisions_json` (JSON string
of this node's decisions). Both `BatchUGCEditingNode` and `BaseUGCEditingNode` accept it
as an optional input and prefer it over the `extra_pnginfo` side-channel. Because the
decision JSON is part of the cached `CacheEntry.outputs`, it travels through the wire
correctly on cache hits without re-executing the node.

The `extra_pnginfo` side-channel writes are preserved for backwards compatibility.

## Required graph change

Connect the new wire for each base branch:
`ShotReview [shot_decisions_json] → BatchUGCEdit [shot_decisions_json]`

Closes #425