### PR TITLE
AMPLIFY-434: Fix id collision on template-duplication

### DIFF
--- a/api-specs/template-service.json
+++ b/api-specs/template-service.json
@@ -405,6 +405,24 @@
               "title": "Project Id"
             },
             "description": "UUID of the target Project to create the template in"
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Override the template name (defaults to the source name)",
+              "title": "Name"
+            },
+            "description": "Override the template name (defaults to the source name)"
           }
         ],
         "responses": {

--- a/frontend/src/app/(protected)/projects/[projectId]/library-templates/[templateId]/page.tsx
+++ b/frontend/src/app/(protected)/projects/[projectId]/library-templates/[templateId]/page.tsx
@@ -28,7 +28,7 @@ import "@xyflow/react/dist/style.css";
 import { Button }      from "@/components/ui/button";
 import { useToast }    from "@/hooks/use-toast";
 import { useTheme } from "next-themes";
-import { createTemplateV1TemplatesPost, getTemplatesByProjectV1TemplatesProjectProjectIdGet } from "@/lib/api/template-service";
+import { duplicateFromLibraryV1TemplatesFromLibraryPost, getTemplatesByProjectV1TemplatesProjectProjectIdGet } from "@/lib/api/template-service";
 import { getLibraryTemplate, type LibraryTemplate } from "@/features/templates/hooks/useLibraryTemplates";
 
 import { AmplifyNode }      from "@/features/canvas/components/AmplifyNode";
@@ -199,12 +199,11 @@ export default function LibraryTemplatePreviewPage() {
         counter++;
       }
 
-      const { data: newTpl } = await createTemplateV1TemplatesPost({
-        body: {
+      const { data: newTpl } = await duplicateFromLibraryV1TemplatesFromLibraryPost({
+        query: {
+          library_template_id: templateId,
           project_id: projectId,
           name: candidateName,
-          description: template.description ?? undefined,
-          current_graph_json: template.graph_json ?? {},
         },
         throwOnError: true,
       });

--- a/frontend/src/lib/api/generated/template-service/types.gen.ts
+++ b/frontend/src/lib/api/generated/template-service/types.gen.ts
@@ -1416,6 +1416,12 @@ export type DuplicateFromLibraryV1TemplatesFromLibraryPostData = {
          * UUID of the target Project to create the template in
          */
         project_id: string;
+        /**
+         * Name
+         *
+         * Override the template name (defaults to the source name)
+         */
+        name?: string | null;
     };
     url: '/v1/templates/from-library';
 };

--- a/template-service/backend_template/services/project_template.py
+++ b/template-service/backend_template/services/project_template.py
@@ -24,6 +24,7 @@ from backend_template.models.template_version import TemplateVersion
 from backend_template.repositories.project_template import ProjectTemplateRepository
 from backend_template.repositories.library_template import LibraryTemplateRepository
 from backend_template.utils.broker import PROJECT_TEMPLATE_EVENTS_EXCHANGE, publish_event
+from backend_template.utils.graph import remap_node_ids
 
 
 class ProjectTemplateService:
@@ -200,12 +201,14 @@ class ProjectTemplateService:
                 detail=f"LibraryTemplate with ID {library_template_id} not found.",
             )
 
-        # 2. Create a new ProjectTemplate with the copied data
+        # 2. Create a new ProjectTemplate with the copied data.
+        #    Remap all node IDs so parallel runs of two duplicated templates
+        #    do not produce colliding NodeStatusChangedEvents (AMPLIFY-434).
         orm_template = await self.repo.create(
             project_id=project_id,
             name=source.name,
             description=source.description,
-            current_graph_json=source.graph_json,
+            current_graph_json=remap_node_ids(source.graph_json),
         )
 
         # 3. Return as Pydantic response

--- a/template-service/backend_template/services/project_template.py
+++ b/template-service/backend_template/services/project_template.py
@@ -187,7 +187,7 @@ class ProjectTemplateService:
         )
 
     async def duplicate_from_library(
-        self, library_template_id: UUID, project_id: UUID
+        self, library_template_id: UUID, project_id: UUID, *, name: str | None = None
     ) -> ProjectTemplateResponse:
         """
         Duplicates a read-only LibraryTemplate into a new editable ProjectTemplate.
@@ -206,7 +206,7 @@ class ProjectTemplateService:
         #    do not produce colliding NodeStatusChangedEvents (AMPLIFY-434).
         orm_template = await self.repo.create(
             project_id=project_id,
-            name=source.name,
+            name=name if name is not None else source.name,
             description=source.description,
             current_graph_json=remap_node_ids(source.graph_json),
         )

--- a/template-service/backend_template/utils/graph.py
+++ b/template-service/backend_template/utils/graph.py
@@ -1,3 +1,6 @@
+import copy
+import uuid
+
 # Frontend-only node schemas that must never be submitted to ComfyUI.
 # - FRONTEND_SINK_SCHEMAS: pure output sinks (no outputs) — drop entirely.
 #   CacheZoneNode is a UI decorator with no ComfyUI equivalent — drop it too.
@@ -13,6 +16,44 @@ _FRONTEND_SINK_SCHEMAS: frozenset[str] = frozenset({
 _FRONTEND_SOURCE_SCHEMAS: frozenset[str] = frozenset({
     "ImportMediaNode",
 })
+
+
+def remap_node_ids(graph: dict) -> dict:
+    """
+    Returns a deep copy of a ReactFlow graph with all node IDs replaced by new UUIDs.
+
+    Remaps:
+      - nodes[i].id
+      - edges[i].source
+      - edges[i].target
+
+    Port IDs (sourceHandle, targetHandle, ports[i].id) are NOT remapped —
+    they are scoped to their node and do not need to be globally unique.
+
+    If the graph is empty or missing "nodes"/"edges" keys, it is returned as-is
+    (deep copied) without raising an exception.
+    """
+    graph = copy.deepcopy(graph)
+    nodes: list[dict] = graph.get("nodes") or []
+    edges: list[dict] = graph.get("edges") or []
+
+    id_map: dict[str, str] = {
+        node["id"]: str(uuid.uuid4())
+        for node in nodes
+        if "id" in node
+    }
+
+    for node in nodes:
+        if "id" in node:
+            node["id"] = id_map[node["id"]]
+
+    for edge in edges:
+        if edge.get("source") in id_map:
+            edge["source"] = id_map[edge["source"]]
+        if edge.get("target") in id_map:
+            edge["target"] = id_map[edge["target"]]
+
+    return graph
 
 
 def convert_reactflow_to_comfy(graph: dict) -> dict:

--- a/template-service/backend_template/web/routes/http/v1/project_template.py
+++ b/template-service/backend_template/web/routes/http/v1/project_template.py
@@ -159,10 +159,11 @@ async def duplicate_from_library(
     service: Service,
     library_template_id: UUID = Query(..., description="UUID of the source LibraryTemplate to clone"),
     project_id: UUID = Query(..., description="UUID of the target Project to create the template in"),
+    name: str | None = Query(None, description="Override the template name (defaults to the source name)"),
 ):
     """
     Duplicates a read-only Library Template into a new editable Project Template.
     No JSON body required — the backend fetches the source template and copies its graph.
     """
-    return await service.duplicate_from_library(library_template_id, project_id)
+    return await service.duplicate_from_library(library_template_id, project_id, name=name)
 

--- a/template-service/poetry.lock
+++ b/template-service/poetry.lock
@@ -613,12 +613,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "cryptography"
@@ -1373,6 +1373,18 @@ test = ["flufl.flake8", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest 
 type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -2060,7 +2072,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -2190,6 +2202,22 @@ mic = ["olefile"]
 test-arrow = ["arro3-compute", "arro3-core", "nanoarrow", "pyarrow"]
 tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma (>=5)", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
 xmp = ["defusedxml"]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "propcache"
@@ -2646,7 +2674,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -2672,6 +2700,28 @@ crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -3991,4 +4041,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "5b6ec7aec17cd50bd6609b54f8660f11d6dd7e013a16b5bc690b75ba68a3e32b"
+content-hash = "b7437f201f9a050526992433bf9513c7e57a9a5f46423fbe3506512f2be73020"

--- a/template-service/pyproject.toml
+++ b/template-service/pyproject.toml
@@ -38,6 +38,9 @@ packages = [
 [tool.poetry.scripts]
 export-spec = "scripts.export_spec:main"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.1.1"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/template-service/tests/test_remap_node_ids.py
+++ b/template-service/tests/test_remap_node_ids.py
@@ -1,0 +1,109 @@
+import uuid
+
+import pytest
+
+from backend_template.utils.graph import remap_node_ids
+
+
+def _make_graph(node_ids: list[str]) -> dict:
+    """Build a minimal ReactFlow graph with the given node IDs connected in a chain."""
+    nodes = [
+        {"id": nid, "data": {"schemaName": "SomeNode", "config": {}, "ports": []}}
+        for nid in node_ids
+    ]
+    edges = [
+        {
+            "source": node_ids[i],
+            "sourceHandle": "output",
+            "target": node_ids[i + 1],
+            "targetHandle": "input",
+        }
+        for i in range(len(node_ids) - 1)
+    ]
+    return {"nodes": nodes, "edges": edges}
+
+
+class TestRemapNodeIds:
+    def test_all_node_ids_are_replaced(self):
+        original_ids = [str(uuid.uuid4()) for _ in range(3)]
+        graph = _make_graph(original_ids)
+
+        result = remap_node_ids(graph)
+
+        result_ids = [n["id"] for n in result["nodes"]]
+        for old_id in original_ids:
+            assert old_id not in result_ids
+
+    def test_new_ids_are_valid_uuids(self):
+        original_ids = [str(uuid.uuid4()) for _ in range(2)]
+        graph = _make_graph(original_ids)
+
+        result = remap_node_ids(graph)
+
+        for node in result["nodes"]:
+            uuid.UUID(node["id"])  # raises if not a valid UUID
+
+    def test_edges_updated_to_new_ids(self):
+        original_ids = [str(uuid.uuid4()) for _ in range(3)]
+        graph = _make_graph(original_ids)
+
+        result = remap_node_ids(graph)
+
+        new_ids = {n["id"] for n in result["nodes"]}
+        for edge in result["edges"]:
+            assert edge["source"] in new_ids
+            assert edge["target"] in new_ids
+
+    def test_two_duplicates_have_disjoint_ids(self):
+        original_ids = [str(uuid.uuid4()) for _ in range(3)]
+        graph = _make_graph(original_ids)
+
+        copy_a = remap_node_ids(graph)
+        copy_b = remap_node_ids(graph)
+
+        ids_a = {n["id"] for n in copy_a["nodes"]}
+        ids_b = {n["id"] for n in copy_b["nodes"]}
+        assert ids_a.isdisjoint(ids_b)
+
+    def test_original_graph_is_not_mutated(self):
+        original_ids = [str(uuid.uuid4()) for _ in range(2)]
+        graph = _make_graph(original_ids)
+
+        remap_node_ids(graph)
+
+        assert [n["id"] for n in graph["nodes"]] == original_ids
+
+    def test_port_ids_are_preserved(self):
+        nid = str(uuid.uuid4())
+        graph = {
+            "nodes": [
+                {
+                    "id": nid,
+                    "data": {
+                        "schemaName": "SomeNode",
+                        "config": {},
+                        "ports": [{"id": "my-port", "direction": "output"}],
+                    },
+                }
+            ],
+            "edges": [],
+        }
+
+        result = remap_node_ids(graph)
+
+        assert result["nodes"][0]["data"]["ports"][0]["id"] == "my-port"
+
+    def test_empty_graph_does_not_raise(self):
+        assert remap_node_ids({}) == {}
+        assert remap_node_ids({"nodes": [], "edges": []}) == {"nodes": [], "edges": []}
+
+    def test_node_config_is_preserved(self):
+        nid = str(uuid.uuid4())
+        graph = {
+            "nodes": [{"id": nid, "data": {"schemaName": "X", "config": {"prompt": "hello"}, "ports": []}}],
+            "edges": [],
+        }
+
+        result = remap_node_ids(graph)
+
+        assert result["nodes"][0]["data"]["config"]["prompt"] == "hello"

--- a/wiki/issues/AMPLIFY-434/concepts/graph-json-format.md
+++ b/wiki/issues/AMPLIFY-434/concepts/graph-json-format.md
@@ -1,0 +1,62 @@
+# Concept: graph_json Format
+
+## Storage
+
+Хранится в колонке `current_graph_json` (JSONB) в таблице `project_templates` (и `library_templates`).
+
+## Structure (ReactFlow format)
+
+```json
+{
+  "nodes": [
+    {
+      "id": "<uuid-string>",
+      "type": "...",
+      "data": {
+        "schemaName": "VeoModel",
+        "config": { "prompt": "...", ... },
+        "ports": [
+          { "id": "<port-id>", "direction": "input"|"output", "isAutogrowSlot": false, ... }
+        ],
+        "_meta": { "can_use_cache": false }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source": "<node-uuid>",
+      "sourceHandle": "<port-id>",
+      "target": "<node-uuid>",
+      "targetHandle": "<port-id>"
+    }
+  ]
+}
+```
+
+## What needs to be unique globally
+
+- `nodes[i].id` — UUID ноды. Используется как ключ в ComfyUI prompt, как `node_id` в
+  `NodeExecution` и в `NodeStatusChangedEvent`. **Должен быть уникален между шаблонами.**
+
+## What is NOT globally unique (scoped to node)
+
+- `nodes[i].data.ports[i].id` — port/handle ID. Уникален только внутри ноды.
+- `edges[i].sourceHandle` / `edges[i].targetHandle` — ссылаются на port IDs.
+
+## Conversion to ComfyUI format
+
+`utils/graph.py:convert_reactflow_to_comfy()` преобразует ReactFlow → ComfyUI:
+```json
+{
+  "<node-uuid>": {
+    "class_type": "VeoModel",
+    "inputs": {
+      "prompt": "...",
+      "video": ["<source-node-uuid>", 0]
+    }
+  }
+}
+```
+
+Node UUID становится ключом в ComfyUI prompt dict. Ссылки на upstream ноды сохраняют
+те же UUIDs в формате `["upstream-node-uuid", output_slot_index]`.

--- a/wiki/issues/AMPLIFY-434/concepts/node-id-lifecycle.md
+++ b/wiki/issues/AMPLIFY-434/concepts/node-id-lifecycle.md
@@ -1,0 +1,50 @@
+# Concept: Node ID Lifecycle
+
+## Origin
+
+Node ID — UUID-строка, генерируется фронтендом при добавлении ноды на canvas.
+Хранится как `nodes[i].id` в `graph_json`.
+
+## Flow
+
+```
+graph_json (ReactFlow)
+  → convert_reactflow_to_comfy()
+  → ComfyUI prompt dict (node UUID = key)
+  → GraphWorkflow (Temporal)
+  → NodeActivityInput.node_id
+  → publish_node_status(job_id, node_id, ...)
+  → NodeStatusChangedEvent (RabbitMQ)
+  → WebSocket Gateway
+  → Frontend canvas (сопоставляет по node_id с нодами на canvas)
+```
+
+Также:
+```
+GraphWorkflow.run_node(nid)
+  → NodeExecution record (node_id = nid, job_id = job_id)
+```
+
+## Collision scenario
+
+Два Project Template, скопированных из одного Library Template:
+- Template A: node IDs = {uuid-1, uuid-2, uuid-3}
+- Template B: node IDs = {uuid-1, uuid-2, uuid-3}  (одинаковые!)
+
+При параллельном запуске:
+- Job A (job_id=JA) и Job B (job_id=JB) — разные
+- Но `NodeStatusChangedEvent` содержит `node_id=uuid-1` без привязки к шаблону
+- Фронтенд, отображающий Template A, видит события для `uuid-1` от Job B
+- Результат: некорректные обновления статуса, "обновления не приходят" для правильного шаблона
+
+## Why job_id alone doesn't fix it
+
+Frontend подписывается на обновления и матчит события по `node_id` для конкретного canvas.
+Если два шаблона имеют одинаковые `node_id`, события перекрываются на уровне UI routing.
+
+## Fix
+
+Ремаппинг `nodes[i].id` при дублировании (в `duplicate_from_library`).
+Новые UUIDs генерируются сервисом, не фронтендом. Edges обновляются соответственно.
+
+Связанные концепции: [[graph-json-format]]

--- a/wiki/issues/AMPLIFY-434/decisions.md
+++ b/wiki/issues/AMPLIFY-434/decisions.md
@@ -1,0 +1,9 @@
+# Decisions: AMPLIFY-434
+
+> Populated during implementation. Each entry records a deviation from plan.md.
+> Updated inline as deviations happen — not retroactively at PR time.
+
+<!-- ## [YYYY-MM-DD] [Short title]
+**What changed:** ...
+**Why:** ...
+**Impact on plan.md:** ... -->

--- a/wiki/issues/AMPLIFY-434/log.md
+++ b/wiki/issues/AMPLIFY-434/log.md
@@ -1,0 +1,5 @@
+# Log: AMPLIFY-434
+
+## 2026-06-30
+
+Прочитан GitHub issue #434. Исследован код: `duplicate_from_library`, `utils/graph.py`, `models/node_execution.py`, temporal workflow. Создан plan.md, research.md, два concept-файла. Определён вариант реализации: `remap_node_ids()` в utils/graph.py + вызов при дублировании.

--- a/wiki/issues/AMPLIFY-434/plan.md
+++ b/wiki/issues/AMPLIFY-434/plan.md
@@ -1,0 +1,63 @@
+# AMPLIFY-434: Fix ID Collision on Template Duplication
+
+## Goal
+
+Remapping node IDs при дублировании Library Template в Project Template, чтобы каждый экземпляр имел уникальные IDs нод и мог исполняться параллельно.
+
+## Context
+
+Граф шаблона хранится в `current_graph_json` (JSONB) в ReactFlow-формате:
+```json
+{
+  "nodes": [{ "id": "<uuid>", "data": { "schemaName": "...", "config": {}, "ports": [] } }],
+  "edges": [{ "source": "<node-uuid>", "target": "<node-uuid>", "sourceHandle": "<port-id>", "targetHandle": "<port-id>" }]
+}
+```
+
+Node IDs из этого JSON используются в трёх местах:
+1. `NodeExecution.node_id` — в БД, для трекинга статуса каждой ноды в рамках job
+2. `NodeStatusChangedEvent.node_id` — в RabbitMQ-событиях → WebSocket Gateway → Frontend
+3. Внутри `graph_json` при конвертации в ComfyUI-формат: `["source_node_id", slot_index]`
+
+**Путь дублирования**: `POST /v1/templates/from-library` →
+`ProjectTemplateService.duplicate_from_library` → копирует `graph_json` как есть.
+
+Когда два Project Template созданы из одного Library Template, у них одинаковые node IDs.
+При параллельном запуске события от одного шаблона попадают на canvas другого — фронтенд
+получает дублированные / неправильно атрибутированные обновления.
+
+## Design Decisions
+
+**Где фиксить**: в сервисном слое — `ProjectTemplateService.duplicate_from_library`.
+Не на уровне репозитория и не в момент запуска (runtime). Причина: граф должен быть
+уникальным с момента создания шаблона, а не только во время исполнения.
+
+**Что ремаппить**: только `nodes[i].id`, `edges[i].source`, `edges[i].target`.
+- `edges[i].sourceHandle` / `edges[i].targetHandle` — это port IDs, они
+  не являются node IDs и глобально не уникальны (их уникальность в скоупе ноды).
+- `nodes[i].data.ports[i].id` — то же: port ID, не node ID, не трогаем.
+- Если `graph_json` пустой или не ReactFlow-формата — пропускаем ремаппинг без ошибки.
+
+**Алгоритм**:
+1. Deep copy `graph_json`
+2. Построить `old_id → new_uuid` маппинг по всем `nodes[i].id`
+3. Заменить `nodes[i].id` на `new_uuid`
+4. Заменить `edges[i].source` и `edges[i].target` через маппинг
+
+**Где реализовать**: вынести в `backend_template/utils/graph.py` как `remap_node_ids(graph: dict) -> dict`.
+Вызывать из `duplicate_from_library`.
+
+## Acceptance Criteria
+
+- [ ] Два Project Template, созданных из одного Library Template, имеют разные node IDs во всех нодах
+- [ ] Edges корректно обновлены: source/target ссылаются на новые IDs
+- [ ] Внутренняя структура нод (config, ports, schemaName) не изменена
+- [ ] Параллельный запуск двух таких шаблонов не вызывает перекрёстных NodeStatusChangedEvent на фронтенде
+- [ ] Юнит-тест на `remap_node_ids`: проверяет что все IDs уникальны и edges обновлены
+- [ ] Пустой / невалидный `graph_json` обрабатывается без exception
+
+## Out of Scope
+
+- Дублирование Project Template → Project Template (такого endpoint'а сейчас нет)
+- Ремаппинг port IDs (они не глобальные, коллизий не создают)
+- Изменения в WebSocket Gateway или фронтенде

--- a/wiki/issues/AMPLIFY-434/research.md
+++ b/wiki/issues/AMPLIFY-434/research.md
@@ -1,0 +1,23 @@
+# Research: AMPLIFY-434
+
+## Overview
+
+При дублировании Library Template в Project Template (`POST /v1/templates/from-library`)
+`graph_json` копируется как есть. Node IDs в скопированном графе идентичны исходному.
+
+Это вызывает коллизию: `NodeStatusChangedEvent` содержит `node_id`, который совпадает у
+нескольких шаблонов. Фронтенд, подписанный на canvas одного шаблона, получает события от
+другого (дубля), что выражается в некорректных обновлениях статуса нод.
+
+Исправление: добавить `remap_node_ids()` в `utils/graph.py` и вызывать её при дублировании.
+
+## Concepts
+
+| Concept | Summary |
+|---------|---------|
+| [[concepts/graph-json-format]] | ReactFlow-формат графа, хранение в БД, поля node/edge |
+| [[concepts/node-id-lifecycle]] | Как node ID используется от graph_json до RabbitMQ события |
+
+## Open Questions
+
+_(нет открытых вопросов — решение определено)_

--- a/wiki/issues/index.md
+++ b/wiki/issues/index.md
@@ -12,3 +12,4 @@
 | [AMPLIFY-416](AMPLIFY-416/plan.md) | Dashboard bug fixes — Capital Burn & CPA charts      | In progress | Hash-based model colors; zero-pad missing dates on frontend; dynamic period labels                    |
 | [AMPLIFY-418](AMPLIFY-418/plan.md) | Telegram notifications for pipeline status updates   | In progress | Delivery via ws-gateway; per-node toggle; ws-gateway owns notification_settings DB                    |
 | [AMPLIFY-419](AMPLIFY-419/plan.md) | Temporal-based job execution engine                  | In progress | Full ComfyUI replacement; nodes as Temporal activities; DAG via topological batches; HITL via signals |
+| [AMPLIFY-434](AMPLIFY-434/plan.md) | Fix ID Collision on Template Duplication             | In progress | remap_node_ids() при duplicate_from_library; новые UUID для нод, обновление edges                    |


### PR DESCRIPTION
Пофиксил баг с тем, что при копировании из библиотеки шаблонов копируются и id нод, что приводит к неожиданному поведению. 
Closes #434 